### PR TITLE
PutMarkLogicRecord logging now reports the correct number of document…

### DIFF
--- a/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/PutMarkLogicRecord.java
+++ b/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/PutMarkLogicRecord.java
@@ -163,6 +163,7 @@ public class PutMarkLogicRecord extends PutMarkLogic {
                     final String uriKey = uriFieldName == null ? UUID.randomUUID().toString() : record.getAsString(uriFieldName);
                     WriteEvent writeEvent = buildWriteEvent(context, session, flowFile, uriKey, bytesHandle, additionalAttributes);
                     this.addWriteEvent(writeBatcher, writeEvent);
+                    added++;
                 }
             }
         } catch (SchemaNotFoundException | IOException | MalformedRecordException e) {


### PR DESCRIPTION
…s inserted

I have an rjrudin/42-fix-logging branch as well, but that has a lot of refactoring on it. Submitting this so that the change is isolated and easy to understand. 

Will wait to add an integration test to verify this (I think we can do it by inspecting the provenance report) until a separate is merged into develop, which has support for JUnit5-based tests.