### PR TITLE
#9 Permissions are now evaluated against FlowFile attributes

### DIFF
--- a/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/AbstractMarkLogicProcessorTest.java
+++ b/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/AbstractMarkLogicProcessorTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.nifi.marklogic.processor;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.nifi.marklogic.controller.DefaultMarkLogicDatabaseClientService;
@@ -71,7 +73,11 @@ public class AbstractMarkLogicProcessorTest extends Assert {
     }
 
     protected MockFlowFile addFlowFile(String... contents) {
-        MockFlowFile flowFile = processSession.createFlowFile(String.join("\n", contents).getBytes());
+        return addFlowFile(new HashMap(), contents);
+    }
+
+    protected MockFlowFile addFlowFile(Map<String, String> attributes, String... contents) {
+        MockFlowFile flowFile = processSession.createFlowFile(String.join("\n", contents).getBytes(), attributes);
         sharedSessionState.getFlowFileQueue().offer(flowFile);
         return flowFile;
     }


### PR DESCRIPTION
This PR also addresses https://github.com/marklogic/nifi/issues/64 , which is a bug where permissions with the same role were not supported.

Also addresses https://github.com/marklogic/nifi/issues/63 . 