### PR TITLE
#7 New processor for evaluating a DHF collector

### DIFF
--- a/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/gradle.properties
+++ b/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/gradle.properties
@@ -2,6 +2,7 @@ mlAppName=test-marklogic-nifi
 mlRestPort=8006
 mlContentForestsPerHost=1
 mlConfigPaths=src/test/ml-config
+mlModulePaths=src/test/ml-modules
 
 # Please define these in gradle-local.properties
 mlUsername=

--- a/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/AbstractMarkLogicProcessor.java
+++ b/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/AbstractMarkLogicProcessor.java
@@ -31,6 +31,7 @@ import org.apache.nifi.components.AllowableValue;
 import org.apache.nifi.components.PropertyDescriptor;
 import org.apache.nifi.components.Validator;
 import org.apache.nifi.expression.ExpressionLanguageScope;
+import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.marklogic.controller.MarkLogicDatabaseClientService;
 import org.apache.nifi.processor.AbstractSessionFactoryProcessor;
 import org.apache.nifi.processor.ProcessContext;
@@ -251,4 +252,18 @@ public abstract class AbstractMarkLogicProcessor extends AbstractSessionFactoryP
         throw new ProcessException(rootCause);
     }
 
+    /**
+     * See https://github.com/marklogic/nifi/issues/21 for details on why the calls to transfer and commit are within
+     * a synchronized block.
+     *
+     * @param session
+     * @param flowFile
+     * @param relationship
+     */
+    protected void transferAndCommit(ProcessSession session, FlowFile flowFile, Relationship relationship) {
+        synchronized (session) {
+            session.transfer(flowFile, relationship);
+            session.commit();
+        }
+    }
 }

--- a/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/EvaluateCollectorMarkLogic.java
+++ b/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/EvaluateCollectorMarkLogic.java
@@ -1,0 +1,345 @@
+package org.apache.nifi.marklogic.processor;
+
+import com.marklogic.client.DatabaseClient;
+import com.marklogic.client.eval.EvalResultIterator;
+import com.marklogic.client.eval.ServerEvaluationCall;
+import com.marklogic.client.io.Format;
+import com.marklogic.client.io.StringHandle;
+import org.apache.nifi.annotation.behavior.*;
+import org.apache.nifi.annotation.documentation.CapabilityDescription;
+import org.apache.nifi.annotation.documentation.Tags;
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.components.Validator;
+import org.apache.nifi.expression.ExpressionLanguageScope;
+import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.flowfile.attributes.FragmentAttributes;
+import org.apache.nifi.processor.*;
+import org.apache.nifi.processor.exception.ProcessException;
+import org.apache.nifi.processor.util.StandardValidators;
+
+import java.util.*;
+
+/**
+ * Evaluates the collector module in a Data Hub Framework harmonize flow. The results are written as new FlowFiles, with
+ * each FlowFile containing a number of identifiers matching the value of the "batch size" property.
+ * <p>
+ * This processor allows input but does not require it. This allows for it to be the start of a flow - e.g. a flow that
+ * runs every hour and collects identifiers to harmonize - or to run after another processor - e.g. a flow that may
+ * first ingest data and then kick off a harmonization process.
+ */
+@Tags({"MarkLogic", "REST", "Data Hub Framework"})
+@InputRequirement(InputRequirement.Requirement.INPUT_ALLOWED)
+@CapabilityDescription("Evaluates a MarkLogic Data Hub Framework collector and creates a FlowFile for each batch of identifiers")
+@SystemResourceConsideration(resource = SystemResource.MEMORY, description = "In order to set fragment.count on each FlowFile, all of the " +
+	"FlowFiles must be temporarily stored in memory so that the count can be determined.")
+@WritesAttributes({
+	@WritesAttribute(attribute = "fragment.identifier", description = "All split FlowFiles produced from the same parent FlowFile will have the same randomly generated UUID added for this attribute."),
+	@WritesAttribute(attribute = "fragment.index", description = "A one-up number that indicates the ordering of the split FlowFiles that were created from a single parent FlowFile."),
+	@WritesAttribute(attribute = "fragment.count", description = "The number of new FlowFiles created from the identifiers returned by the collector. Only set if 'Set Fragment Count' is true."),
+	@WritesAttribute(attribute = "dhf.collector.identifiers.total", description = "The count of identifiers returned by the collector. Only set if 'Set Fragment Count' is true.")
+})
+public class EvaluateCollectorMarkLogic extends AbstractMarkLogicProcessor {
+
+	public static final String FRAGMENT_ID = FragmentAttributes.FRAGMENT_ID.key();
+	public static final String FRAGMENT_INDEX = FragmentAttributes.FRAGMENT_INDEX.key();
+	public static final String FRAGMENT_COUNT = FragmentAttributes.FRAGMENT_COUNT.key();
+
+	public static final String SCRIPT_TYPE_XQUERY = "XQuery";
+	public static final String SCRIPT_TYPE_JAVASCRIPT = "JavaScript";
+
+	public static final String IDENTIFIERS_ATTRIBUTE = "dhf.collector.identifiers";
+	public static final String IDENTIFIERS_TOTAL_ATTRIBUTE = "dhf.collector.identifiers.total";
+
+	public static final PropertyDescriptor ENTITY_NAME = new PropertyDescriptor.Builder()
+		.name("Entity Name")
+		.displayName("Entity Name")
+		.description("The name of the entity associated with the collector you wish to run. If set, Flow Name should be set as well. " +
+			"Assumes that the collector module is written in SJS. If this is not the case, use SCRIPT_BODY instead.")
+		.required(false)
+		.addValidator(Validator.VALID)
+		.expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+		.build();
+
+	public static final PropertyDescriptor FLOW_NAME = new PropertyDescriptor.Builder()
+		.name("Flow Name")
+		.displayName("Flow Name")
+		.description("The name of the harmonize flow associated with the collector you wish to run. If set, Entity Name should be set as well." +
+			"Assumes that the collector module is written in SJS. If this is not the case, use SCRIPT_BODY instead.")
+		.required(false)
+		.addValidator(Validator.VALID)
+		.expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+		.build();
+
+	public static final PropertyDescriptor OPTIONS = new PropertyDescriptor.Builder()
+		.name("Options")
+		.displayName("Options")
+		.description("An optional JSON object defining options that are passed to the collector module.")
+		.required(false)
+		.addValidator(Validator.VALID)
+		.expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+		.build();
+
+	public static final PropertyDescriptor SCRIPT_BODY = new PropertyDescriptor.Builder()
+		.name("Script Body")
+		.displayName("Script Body")
+		.description("A JavaScript or XQuery script to evaluate that runs a collector. When using this, Entity Name and Flow Name will be ignored. Use this " +
+			"if your collector is written in XQuery, as the script that is generated via Entity Name and Flow Name assumes that the collector is written in JavaScript.")
+		.required(false)
+		.addValidator(Validator.VALID)
+		.expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+		.build();
+
+	public static final PropertyDescriptor SCRIPT_TYPE = new PropertyDescriptor.Builder()
+		.name("Script Type")
+		.displayName("Script Type")
+		.description("If Script Body is set, set this to define whether the script is JavaScript or XQuery.")
+		.required(false)
+		.allowableValues(SCRIPT_TYPE_JAVASCRIPT, SCRIPT_TYPE_XQUERY)
+		.addValidator(Validator.VALID)
+		.expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+		.build();
+
+	public static final PropertyDescriptor DELIMITER = new PropertyDescriptor.Builder()
+		.name("Delimiter")
+		.displayName("Delimiter")
+		.description("Used to delimiter the identifiers in each FlowFile routed to the 'batches' relationship; " +
+			"the identifiers are stored in a FlowFile attribute named 'collectorIdentifiers'")
+		.required(true)
+		.defaultValue(",")
+		.addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+		.expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+		.build();
+
+	public static final PropertyDescriptor BATCH_SIZE = new PropertyDescriptor.Builder()
+		.name("Batch Size")
+		.displayName("Batch Size")
+		.description("The number of identifiers to include in each FlowFile routed to the 'batches' relationship")
+		.required(true)
+		.defaultValue("100")
+		.addValidator(StandardValidators.POSITIVE_INTEGER_VALIDATOR)
+		.expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+		.build();
+
+	public static final PropertyDescriptor IDENTIFIERS_ATTRIBUTE_NAME = new PropertyDescriptor.Builder()
+		.name("Identifiers Attribute Name")
+		.displayName("Identifiers Attribute Name")
+		.description("The name of the FlowFile attribute that the batch of delimited identifiers is stored in")
+		.required(true)
+		.defaultValue(IDENTIFIERS_ATTRIBUTE)
+		.addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+		.expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+		.build();
+
+	public static final PropertyDescriptor SET_FRAGMENT_COUNT = new PropertyDescriptor.Builder()
+		.name("Set Fragment Count")
+		.displayName("Set Fragment Count")
+		.description("If set to true, then each FlowFile routed to 'batches' will have a fragment.count attribute set. " +
+			"This allows for a processor like MergeContent to know when all of the identifiers have been processed (e.g. via ExtensionCallMarkLogic). " +
+			"Note that, similar to SplitText, this can cause memory issues if the collector returns a large number of identifiers. If you do not need this capability, " +
+			"be sure that this is set to false.")
+		.required(true)
+		.allowableValues("true", "false")
+		.defaultValue("false")
+		.addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+		.expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+		.build();
+
+	protected static final Relationship BATCHES = new Relationship.Builder().name("batches")
+		.description("FlowFiles created from each batch of collected identifiers are routed here")
+		.build();
+
+	protected static final Relationship FAILURE = new Relationship.Builder().name("failure")
+		.description("FlowFiles that were not successfully processed are routed here").build();
+
+	protected static final Relationship ORIGINAL = new Relationship.Builder().name("original")
+		.description("The original FlowFile received by this processor is routed here").build();
+
+	@Override
+	public void init(ProcessorInitializationContext context) {
+		List<PropertyDescriptor> list = new ArrayList<>();
+		list.add(DATABASE_CLIENT_SERVICE);
+		list.add(ENTITY_NAME);
+		list.add(FLOW_NAME);
+		list.add(OPTIONS);
+		list.add(SCRIPT_BODY);
+		list.add(SCRIPT_TYPE);
+		list.add(DELIMITER);
+		list.add(BATCH_SIZE);
+		list.add(IDENTIFIERS_ATTRIBUTE_NAME);
+		list.add(SET_FRAGMENT_COUNT);
+		properties = Collections.unmodifiableList(list);
+
+		Set<Relationship> set = new HashSet<>();
+		set.add(BATCHES);
+		set.add(FAILURE);
+		set.add(ORIGINAL);
+		relationships = Collections.unmodifiableSet(set);
+	}
+
+	/**
+	 * This processor does not require an input FlowFile. If one does not exist, and there's no incoming connection,
+	 * If a FlowFile exists, builds a script to evaluate a DHF collector module. Evaluates the script and then creates
+	 * a new FlowFile for each batch of identifiers in the response, where the size and structure of a batch is
+	 * determined by the Batch Size and Delimiter properties. Each FlowFile has the batch stored as an attribute with
+	 * a name determined by the Identifiers Attribute Name property.
+	 *
+	 * @param context
+	 * @param sessionFactory
+	 * @throws ProcessException
+	 */
+	@Override
+	public void onTrigger(ProcessContext context, ProcessSessionFactory sessionFactory) throws ProcessException {
+		final ProcessSession session = sessionFactory.createSession();
+
+		/**
+		 * At least in NiFi 1.8.0, if this processor has an incoming connection, then onTrigger won't be invoked unless
+		 * a FlowFile exists. So if onTrigger is invoked, either a FlowFile exists, or there's no incoming connection
+		 * and the user does not require any input, and thus a new FlowFile should be created.
+		 */
+		FlowFile flowFile = session.get();
+		if (flowFile == null) {
+			flowFile = session.create();
+		}
+
+		try {
+			final String script = buildScriptToEvaluate(context, flowFile);
+			getLogger().info("Evaluating script: " + script);
+
+			EvalResultIterator iterator = evaluateScript(context, flowFile, script);
+			try {
+				createFlowFilesForBatchesOfIdentifiers(context, session, flowFile, iterator);
+				transferAndCommit(session, flowFile, ORIGINAL);
+			} finally {
+				iterator.close();
+			}
+		} catch (Exception ex) {
+			transferAndCommit(session, flowFile, FAILURE);
+		}
+	}
+
+	protected String buildScriptToEvaluate(ProcessContext context, FlowFile flowFile) {
+		final String scriptBody = context.getProperty(SCRIPT_BODY).evaluateAttributeExpressions(flowFile).getValue();
+		if (scriptBody != null && scriptBody.trim().length() > 0) {
+			return scriptBody;
+		}
+
+		final String entityName = context.getProperty(ENTITY_NAME).evaluateAttributeExpressions(flowFile).getValue();
+		final String flowName = context.getProperty(FLOW_NAME).evaluateAttributeExpressions(flowFile).getValue();
+		return String.format("var options; const collector = require('/entities/%s/harmonize/%s/collector.sjs'); collector.collect(options)",
+			entityName, flowName);
+	}
+
+	protected EvalResultIterator evaluateScript(ProcessContext context, FlowFile flowFile, String script) {
+		final String scriptType = context.getProperty(SCRIPT_TYPE).evaluateAttributeExpressions(flowFile).getValue();
+		final String options = context.getProperty(OPTIONS).evaluateAttributeExpressions(flowFile).getValue();
+
+		DatabaseClient client = getDatabaseClient(context);
+		ServerEvaluationCall call = client.newServerEval();
+		call = SCRIPT_TYPE_XQUERY.equals(scriptType) ? call.xquery(script) : call.javascript(script);
+
+		if (options != null && options.trim().length() > 0) {
+			getLogger().info("Collector options: " + options);
+			call.addVariable("options", new StringHandle(options).withFormat(Format.JSON));
+		}
+
+		return call.eval();
+	}
+
+	/**
+	 * Similar to SplitText, if SET_FRAGMENT_COUNT is set to true, then this needs to generate all of the new FlowFile
+	 * objects first, and then set fragment.count on them before transferring any of them.
+	 *
+	 * @param context
+	 * @param session
+	 * @param flowFile
+	 * @param iterator
+	 */
+	protected void createFlowFilesForBatchesOfIdentifiers(ProcessContext context, ProcessSession session, FlowFile flowFile, EvalResultIterator iterator) {
+		final String delimiter = context.getProperty(DELIMITER).evaluateAttributeExpressions(flowFile).getValue();
+		final int batchSize = context.getProperty(BATCH_SIZE).evaluateAttributeExpressions(flowFile).asInteger();
+		final String identifiersAttributeName = context.getProperty(IDENTIFIERS_ATTRIBUTE_NAME).evaluateAttributeExpressions(flowFile).getValue();
+		final boolean setFragmentCount = context.getProperty(SET_FRAGMENT_COUNT).evaluateAttributeExpressions(flowFile).asBoolean();
+
+		String delimitedIdentifiers = null;
+		int totalIdentifierCount = 0;
+		int identifierCount = 0;
+		int index = 1;
+		final String newFragmentId = UUID.randomUUID().toString();
+
+		List<FlowFile> newFlowFiles = new ArrayList<>();
+
+		// Iterate over all of the identifiers returned by the collector module
+		while (iterator.hasNext()) {
+			final String identifier = iterator.next().getString();
+			if (delimitedIdentifiers != null) {
+				delimitedIdentifiers = delimitedIdentifiers + delimiter + identifier;
+			} else {
+				delimitedIdentifiers = identifier;
+			}
+			identifierCount++;
+			totalIdentifierCount++;
+			// If our count of identifiers equals our batch size, and we don't need to set the fragment count, then
+			// we'll transfer a new FlowFile; otherwise we create one and add it to the list to process later
+			if (identifierCount >= batchSize) {
+				FlowFile newFlowFile = buildNewFlowFile(session, flowFile, index, identifiersAttributeName, delimitedIdentifiers, newFragmentId);
+				if (setFragmentCount) {
+					newFlowFiles.add(newFlowFile);
+				} else {
+					session.transfer(newFlowFile, BATCHES);
+				}
+				index++;
+				identifierCount = 0;
+				delimitedIdentifiers = null;
+			}
+		}
+
+		// If we have any identifiers left (because the current batch never equaled batchSize), then process them
+		if (delimitedIdentifiers != null) {
+			FlowFile newFlowFile = buildNewFlowFile(session, flowFile, index, identifiersAttributeName, delimitedIdentifiers, newFragmentId);
+			if (setFragmentCount) {
+				newFlowFiles.add(newFlowFile);
+			} else {
+				session.transfer(newFlowFile, BATCHES);
+			}
+		}
+
+		if (setFragmentCount) {
+			final String fragmentCount = String.valueOf(newFlowFiles.size());
+			final String collectorIdentifiersCount = String.valueOf(totalIdentifierCount);
+			final ListIterator<FlowFile> flowFileItr = newFlowFiles.listIterator();
+			while (flowFileItr.hasNext()) {
+				FlowFile splitFlowFile = flowFileItr.next();
+				Map<String, String> attributes = new HashMap<>();
+				attributes.put(FRAGMENT_COUNT, fragmentCount);
+				attributes.put(IDENTIFIERS_TOTAL_ATTRIBUTE, collectorIdentifiersCount);
+				final FlowFile updated = session.putAllAttributes(splitFlowFile, attributes);
+				flowFileItr.set(updated);
+			}
+			session.transfer(newFlowFiles, BATCHES);
+			getLogger().info("Finished creating {} FlowFiles for {} identifiers", new Object[]{fragmentCount, totalIdentifierCount});
+		} else {
+			getLogger().info("Finished creating FlowFiles for {} identifiers", new Object[]{totalIdentifierCount});
+		}
+	}
+
+	/**
+	 * Construct a new FlowFile with the delimited identifiers stored as an attribute.
+	 *
+	 * @param session
+	 * @param flowFile
+	 * @param index
+	 * @param identifiersAttributeName
+	 * @param delimitedIdentifiers
+	 * @param fragmentId
+	 * @return
+	 */
+	protected FlowFile buildNewFlowFile(ProcessSession session, FlowFile flowFile, int index,
+	                                    String identifiersAttributeName, String delimitedIdentifiers, String fragmentId) {
+		FlowFile newFlowFile = session.create(flowFile);
+		Map<String, String> attributes = new HashMap<>();
+		attributes.put(FRAGMENT_ID, fragmentId);
+		attributes.put(FRAGMENT_INDEX, String.valueOf(index));
+		attributes.put(identifiersAttributeName, delimitedIdentifiers);
+		return session.putAllAttributes(newFlowFile, attributes);
+	}
+}

--- a/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/ExtensionCallMarkLogic.java
+++ b/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/ExtensionCallMarkLogic.java
@@ -221,10 +221,7 @@ public class ExtensionCallMarkLogic extends AbstractMarkLogicProcessor {
                 session.append(flowFile, out -> out.write(result.getContent(new BytesHandle()).get()));
             }
 
-            synchronized(session) {
-                session.transfer(flowFile, SUCCESS);
-                session.commit();
-            }
+            transferAndCommit(session, flowFile, SUCCESS);
         } catch (final Throwable t) {
             this.handleThrowable(t, session);
         }

--- a/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
+++ b/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
@@ -15,6 +15,7 @@
 
 org.apache.nifi.marklogic.processor.ApplyTransformMarkLogic
 org.apache.nifi.marklogic.processor.DeleteMarkLogic
+org.apache.nifi.marklogic.processor.EvaluateCollectorMarkLogic
 org.apache.nifi.marklogic.processor.ExecuteScriptMarkLogic
 org.apache.nifi.marklogic.processor.ExtensionCallMarkLogic
 org.apache.nifi.marklogic.processor.PutMarkLogic

--- a/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/AbstractMarkLogicIT.java
+++ b/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/AbstractMarkLogicIT.java
@@ -123,9 +123,13 @@ public class AbstractMarkLogicIT extends AbstractSpringMarkLogicTest {
         }
     }
 
-    protected void addDatabaseClientService(TestRunner runner) throws InitializationException {
+    protected void addDatabaseClientService(TestRunner runner) {
         service = new DefaultMarkLogicDatabaseClientService();
-        runner.addControllerService(databaseClientServiceIdentifier, service);
+        try {
+            runner.addControllerService(databaseClientServiceIdentifier, service);
+        } catch (InitializationException e) {
+            throw new RuntimeException(e);
+        }
         runner.setProperty(service, DefaultMarkLogicDatabaseClientService.HOST, testConfig.getHost());
         runner.setProperty(service, DefaultMarkLogicDatabaseClientService.PORT, testConfig.getRestPort().toString());
         runner.setProperty(service, DefaultMarkLogicDatabaseClientService.USERNAME, testConfig.getUsername());
@@ -135,7 +139,7 @@ public class AbstractMarkLogicIT extends AbstractSpringMarkLogicTest {
 
     protected void teardown() {}
 
-    protected TestRunner getNewTestRunner(Class processor) throws InitializationException {
+    protected TestRunner getNewTestRunner(Class processor) {
         TestRunner runner = TestRunners.newTestRunner(processor);
         addDatabaseClientService(runner);
         runner.setProperty(AbstractMarkLogicProcessor.BATCH_SIZE, batchSize);

--- a/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/AbstractMarkLogicProcessorTest.java
+++ b/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/AbstractMarkLogicProcessorTest.java
@@ -44,7 +44,7 @@ public class AbstractMarkLogicProcessorTest extends Assert {
 
     protected ApplicationContext applicationContext;
 
-    protected void initialize(Processor processor) throws InitializationException {
+    protected void initialize(Processor processor) {
         this.processor = processor;
         processContext = new MockProcessContext(processor);
         initializationContext = new MockProcessorInitializationContext(processor, processContext);
@@ -57,7 +57,12 @@ public class AbstractMarkLogicProcessorTest extends Assert {
         applicationContext = new AnnotationConfigApplicationContext(TestConfig.class);
         TestConfig testConfig = applicationContext.getBean(TestConfig.class);
 
-        runner.addControllerService(databaseClientServiceIdentifier, service);
+        try {
+            runner.addControllerService(databaseClientServiceIdentifier, service);
+        } catch (InitializationException e) {
+            throw new RuntimeException(e);
+        }
+
         runner.setProperty(service, DefaultMarkLogicDatabaseClientService.HOST, testConfig.getHost());
         runner.setProperty(service, DefaultMarkLogicDatabaseClientService.PORT, testConfig.getRestPort().toString());
         runner.setProperty(service, DefaultMarkLogicDatabaseClientService.USERNAME, testConfig.getUsername());
@@ -72,6 +77,10 @@ public class AbstractMarkLogicProcessorTest extends Assert {
         runner.enableControllerService(service);
         runner.assertValid(service);
         runner.setProperty(PutMarkLogicRecord.DATABASE_CLIENT_SERVICE, databaseClientServiceIdentifier);
+    }
+
+    protected MockFlowFile addTestFlowFile() {
+        return addFlowFile("<test/>");
     }
 
     protected MockFlowFile addFlowFile(String... contents) {

--- a/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/ApplyTransformMarkLogicIT.java
+++ b/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/ApplyTransformMarkLogicIT.java
@@ -112,8 +112,4 @@ public class ApplyTransformMarkLogicIT extends AbstractMarkLogicIT {
         super.teardown();
         deleteDocumentsInCollection(collection);
     }
-    protected TestRunner getNewTestRunner(Class processor) throws InitializationException {
-        TestRunner runner = super.getNewTestRunner(processor);
-        return runner;
-    }
 }

--- a/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/DeleteMarkLogicIT.java
+++ b/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/DeleteMarkLogicIT.java
@@ -75,8 +75,4 @@ public class DeleteMarkLogicIT extends AbstractMarkLogicIT {
         super.teardown();
         deleteDocumentsInCollection(collection);
     }
-    protected TestRunner getNewTestRunner(Class processor) throws InitializationException {
-        TestRunner runner = super.getNewTestRunner(processor);
-        return runner;
-    }
 }

--- a/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/EvaluateCollectorMarkLogicIT.java
+++ b/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/EvaluateCollectorMarkLogicIT.java
@@ -1,0 +1,67 @@
+package org.apache.nifi.marklogic.processor;
+
+import com.marklogic.client.document.JSONDocumentManager;
+import com.marklogic.client.io.StringHandle;
+import org.apache.nifi.util.MockFlowFile;
+import org.apache.nifi.util.TestRunner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * This just focuses on evaluating the collector script against MarkLogic, as that can't be done in
+ * EvaluateCollectorMarkLogicTest.
+ */
+public class EvaluateCollectorMarkLogicIT extends AbstractMarkLogicIT {
+
+	@BeforeEach
+	public void setup() {
+		JSONDocumentManager mgr = getDatabaseClient().newJSONDocumentManager();
+		for (int i = 0; i < 5; i++) {
+			mgr.write("/test/" + i + ".json", new StringHandle(format("{\"test\":\"%d\"}", i)));
+		}
+
+		batchSize = "2";
+	}
+
+	@Test
+	public void test() {
+		TestRunner runner = getNewTestRunner(EvaluateCollectorMarkLogic.class);
+		runner.setProperty(EvaluateCollectorMarkLogic.ENTITY_NAME, "person");
+		runner.setProperty(EvaluateCollectorMarkLogic.FLOW_NAME, "default");
+
+		runner.run();
+
+		List<MockFlowFile> list = runner.getFlowFilesForRelationship(EvaluateCollectorMarkLogic.BATCHES);
+		assertEquals(3, list.size(), "For 5 docs and a batch size of 2, 3 FlowFiles should have been created");
+	}
+
+	@Test
+	public void customXqueryScript() {
+		TestRunner runner = getNewTestRunner(EvaluateCollectorMarkLogic.class);
+		runner.setProperty(EvaluateCollectorMarkLogic.SCRIPT_TYPE, EvaluateCollectorMarkLogic.SCRIPT_TYPE_XQUERY);
+		runner.setProperty(EvaluateCollectorMarkLogic.SCRIPT_BODY,
+			"import module namespace p = 'http://marklogic.com/data-hub/plugins' at '/entities/person/harmonize/default/collector.xqy'; p:collect(map:map())");
+
+		runner.run();
+
+		List<MockFlowFile> list = runner.getFlowFilesForRelationship(EvaluateCollectorMarkLogic.BATCHES);
+		assertEquals(3, list.size());
+	}
+
+	@Test
+	public void scriptWithOptions() {
+		TestRunner runner = getNewTestRunner(EvaluateCollectorMarkLogic.class);
+		runner.setProperty(EvaluateCollectorMarkLogic.ENTITY_NAME, "person");
+		runner.setProperty(EvaluateCollectorMarkLogic.FLOW_NAME, "default");
+		runner.setProperty(EvaluateCollectorMarkLogic.OPTIONS, "{\"dhf.limit\":3}");
+
+		runner.run();
+
+		List<MockFlowFile> list = runner.getFlowFilesForRelationship(EvaluateCollectorMarkLogic.BATCHES);
+		assertEquals(2, list.size(), "The options should have limited the collector to 3 URIs, and with a batch size of 2, should have created 2 FlowFiles");
+	}
+}

--- a/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/EvaluateCollectorMarkLogicTest.java
+++ b/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/EvaluateCollectorMarkLogicTest.java
@@ -1,0 +1,112 @@
+package org.apache.nifi.marklogic.processor;
+
+import com.marklogic.client.eval.EvalResult;
+import org.apache.nifi.flowfile.attributes.FragmentAttributes;
+import org.apache.nifi.util.MockFlowFile;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class EvaluateCollectorMarkLogicTest extends AbstractMarkLogicProcessorTest {
+
+	private EvaluateCollectorMarkLogic myProcessor;
+
+	@Before
+	public void setup() {
+		myProcessor = new EvaluateCollectorMarkLogic();
+		initialize(myProcessor);
+	}
+
+	@Test
+	public void defaultScript() {
+		processContext.setProperty(EvaluateCollectorMarkLogic.ENTITY_NAME, "person");
+		processContext.setProperty(EvaluateCollectorMarkLogic.FLOW_NAME, "default");
+		assertEquals("var options; const collector = require('/entities/person/harmonize/default/collector.sjs'); collector.collect(options)",
+			myProcessor.buildScriptToEvaluate(processContext, addTestFlowFile()));
+	}
+
+	@Test
+	public void customScript() {
+		processContext.setProperty(EvaluateCollectorMarkLogic.SCRIPT_BODY, "thisCanBeAnything()");
+		assertEquals("thisCanBeAnything()", myProcessor.buildScriptToEvaluate(processContext, addTestFlowFile()));
+	}
+
+	@Test
+	public void entityAndFlowNamesEvaluatedAgainstFlowFile() {
+		processContext.setProperty(EvaluateCollectorMarkLogic.ENTITY_NAME, "${theEntityName}");
+		processContext.setProperty(EvaluateCollectorMarkLogic.FLOW_NAME, "${theFlowName}");
+
+		Map<String, String> attributes = new HashMap<>();
+		attributes.put("theEntityName", "someEntity");
+		attributes.put("theFlowName", "someFlow");
+
+		assertEquals("var options; const collector = require('/entities/someEntity/harmonize/someFlow/collector.sjs'); collector.collect(options)",
+			myProcessor.buildScriptToEvaluate(processContext, addFlowFile(attributes, "test")));
+	}
+
+	@Test
+	public void createFlowFilesWithDefaults() {
+		processContext.setProperty(EvaluateCollectorMarkLogic.BATCH_SIZE, "2");
+
+		myProcessor.createFlowFilesForBatchesOfIdentifiers(processContext, processSession, addTestFlowFile(), buildMockResults());
+
+		List<MockFlowFile> newFlowFiles = processSession.getFlowFilesForRelationship(EvaluateCollectorMarkLogic.BATCHES);
+		assertEquals("There should be 2 flow files, since our fake iterator had 3 ids in it, and the batch size is set to 2", 2, newFlowFiles.size());
+
+		MockFlowFile firstBatch = newFlowFiles.get(0);
+		firstBatch.assertAttributeEquals(EvaluateCollectorMarkLogic.IDENTIFIERS_ATTRIBUTE, "id1,id2");
+		firstBatch.assertAttributeEquals(FragmentAttributes.FRAGMENT_INDEX.key(), "1");
+		firstBatch.assertAttributeNotExists(EvaluateCollectorMarkLogic.IDENTIFIERS_TOTAL_ATTRIBUTE);
+
+		MockFlowFile secondBatch = newFlowFiles.get(1);
+		secondBatch.assertAttributeEquals(EvaluateCollectorMarkLogic.IDENTIFIERS_ATTRIBUTE, "id3");
+		secondBatch.assertAttributeEquals(FragmentAttributes.FRAGMENT_INDEX.key(), "2");
+		secondBatch.assertAttributeNotExists(EvaluateCollectorMarkLogic.IDENTIFIERS_TOTAL_ATTRIBUTE);
+	}
+
+	@Test
+	public void createFlowFilesWithFragmentCountSet() {
+		processContext.setProperty(EvaluateCollectorMarkLogic.SET_FRAGMENT_COUNT, "true");
+		processContext.setProperty(EvaluateCollectorMarkLogic.BATCH_SIZE, "2");
+
+		myProcessor.createFlowFilesForBatchesOfIdentifiers(processContext, processSession, addTestFlowFile(), buildMockResults());
+
+		List<MockFlowFile> newFlowFiles = processSession.getFlowFilesForRelationship(EvaluateCollectorMarkLogic.BATCHES);
+		assertEquals(2, newFlowFiles.size());
+
+		MockFlowFile firstBatch = newFlowFiles.get(0);
+		firstBatch.assertAttributeEquals(EvaluateCollectorMarkLogic.IDENTIFIERS_ATTRIBUTE, "id1,id2");
+		firstBatch.assertAttributeEquals(FragmentAttributes.FRAGMENT_INDEX.key(), "1");
+		firstBatch.assertAttributeEquals(EvaluateCollectorMarkLogic.IDENTIFIERS_TOTAL_ATTRIBUTE, "3");
+
+		MockFlowFile secondBatch = newFlowFiles.get(1);
+		secondBatch.assertAttributeEquals(EvaluateCollectorMarkLogic.IDENTIFIERS_ATTRIBUTE, "id3");
+		secondBatch.assertAttributeEquals(FragmentAttributes.FRAGMENT_INDEX.key(), "2");
+		secondBatch.assertAttributeEquals(EvaluateCollectorMarkLogic.IDENTIFIERS_TOTAL_ATTRIBUTE, "3");
+	}
+
+	@Test
+	public void customDelimiter() {
+		processContext.setProperty(EvaluateCollectorMarkLogic.DELIMITER, ":");
+
+		myProcessor.createFlowFilesForBatchesOfIdentifiers(processContext, processSession, addTestFlowFile(), buildMockResults());
+
+		List<MockFlowFile> newFlowFiles = processSession.getFlowFilesForRelationship(EvaluateCollectorMarkLogic.BATCHES);
+		assertEquals("The batch size defaults to 100, and with 3 fake results, we should have one batch FlowFile", 1, newFlowFiles.size());
+
+		MockFlowFile firstBatch = newFlowFiles.get(0);
+		firstBatch.assertAttributeEquals(EvaluateCollectorMarkLogic.IDENTIFIERS_ATTRIBUTE, "id1:id2:id3");
+	}
+
+	private MockEvalResultIterator buildMockResults() {
+		List<EvalResult> results = new ArrayList<>();
+		results.add(new StringEvalResult("id1"));
+		results.add(new StringEvalResult("id2"));
+		results.add(new StringEvalResult("id3"));
+		return new MockEvalResultIterator(results);
+	}
+}

--- a/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/MockEvalResultIterator.java
+++ b/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/MockEvalResultIterator.java
@@ -1,0 +1,35 @@
+package org.apache.nifi.marklogic.processor;
+
+import com.marklogic.client.eval.EvalResult;
+import com.marklogic.client.eval.EvalResultIterator;
+
+import java.util.Iterator;
+import java.util.List;
+
+public class MockEvalResultIterator implements EvalResultIterator {
+
+	Iterator<EvalResult> iterator;
+
+	public MockEvalResultIterator(List<EvalResult> results) {
+		this.iterator = results.iterator();
+	}
+
+	@Override
+	public Iterator<EvalResult> iterator() {
+		return iterator;
+	}
+
+	@Override
+	public boolean hasNext() {
+		return iterator.hasNext();
+	}
+
+	@Override
+	public EvalResult next() {
+		return iterator.next();
+	}
+
+	@Override
+	public void close() {
+	}
+}

--- a/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/PutMarkLogicIT.java
+++ b/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/PutMarkLogicIT.java
@@ -46,7 +46,7 @@ public class PutMarkLogicIT extends AbstractMarkLogicIT{
         super.teardown();
     }
 
-    public TestRunner getNewTestRunner(Class processor) throws InitializationException {
+    public TestRunner getNewTestRunner(Class processor) {
         TestRunner runner = super.getNewTestRunner(processor);
         runner.setProperty(PutMarkLogic.URI_ATTRIBUTE_NAME, "filename");
         return runner;

--- a/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/QueryMarkLogicIT.java
+++ b/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/QueryMarkLogicIT.java
@@ -78,7 +78,7 @@ public class QueryMarkLogicIT extends AbstractMarkLogicIT {
         //deleteDocumentsInCollection(collection);
     }
 
-    protected TestRunner getNewTestRunner(Class processor) throws InitializationException {
+    protected TestRunner getNewTestRunner(Class processor) {
         TestRunner runner = super.getNewTestRunner(processor);
         runner.assertNotValid();
         runner.setProperty(QueryMarkLogic.CONSISTENT_SNAPSHOT, "true");

--- a/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/StringEvalResult.java
+++ b/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/StringEvalResult.java
@@ -1,0 +1,51 @@
+package org.apache.nifi.marklogic.processor;
+
+import com.marklogic.client.eval.EvalResult;
+import com.marklogic.client.io.BytesHandle;
+import com.marklogic.client.io.Format;
+import com.marklogic.client.io.StringHandle;
+import com.marklogic.client.io.marker.AbstractReadHandle;
+
+public class StringEvalResult implements EvalResult {
+
+	private String value;
+
+	public StringEvalResult(String value) {
+		this.value = value;
+	}
+
+	@Override
+	public Type getType() {
+		return Type.STRING;
+	}
+
+	@Override
+	public Format getFormat() {
+		return Format.TEXT;
+	}
+
+	@Override
+	public <H extends AbstractReadHandle> H get(H h) {
+		return (H)new StringHandle(value);
+	}
+
+	@Override
+	public <T> T getAs(Class<T> aClass) {
+		return (T)String.class;
+	}
+
+	@Override
+	public String getString() {
+		return value;
+	}
+
+	@Override
+	public Number getNumber() {
+		return null;
+	}
+
+	@Override
+	public Boolean getBoolean() {
+		return null;
+	}
+}

--- a/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/test/ml-modules/root/entities/person/harmonize/default/README.md
+++ b/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/test/ml-modules/root/entities/person/harmonize/default/README.md
@@ -1,0 +1,2 @@
+For testing EvaluateCollectorMarkLogic, we don't need a full DHF project - we just 
+need a single collector module, which is what the module in this directory is for.

--- a/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/test/ml-modules/root/entities/person/harmonize/default/collector.sjs
+++ b/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/test/ml-modules/root/entities/person/harmonize/default/collector.sjs
@@ -1,0 +1,11 @@
+function collect(options) {
+	var limit = options != null && options.hasOwnProperty('dhf.limit') ?
+		parseInt(options['dhf.limit']) :
+		Number.MAX_SAFE_INTEGER;
+
+	return cts.uris(null, 'limit=' + limit, cts.trueQuery());
+}
+
+module.exports = {
+	collect: collect
+};

--- a/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/test/ml-modules/root/entities/person/harmonize/default/collector.xqy
+++ b/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/test/ml-modules/root/entities/person/harmonize/default/collector.xqy
@@ -1,0 +1,11 @@
+xquery version "1.0-ml";
+
+module namespace plugin = "http://marklogic.com/data-hub/plugins";
+
+declare option xdmp:mapping "false";
+
+declare function plugin:collect($options as map:map) as xs:string*
+{
+	cts:uris((), (), cts:true-query())
+};
+


### PR DESCRIPTION
The intent is for this to be used to collect all the identifiers via a harmonization flow's collector module. Batches (of configurable size) of identifiers are then streamed out of ML and written as new FlowFiles for the next processor to process. As shown in the attached images, the next processor is likely an instance of ExtensionCallMarkLogic, which passes the identifiers to the DHF flow endpoint. 

<img width="1058" alt="collector" src="https://user-images.githubusercontent.com/5026193/54778098-32e7e700-4bea-11e9-901c-40fd7418bd6e.png">

<img width="834" alt="collector-properties" src="https://user-images.githubusercontent.com/5026193/54778099-32e7e700-4bea-11e9-887b-5d909ffd8124.png">

