### PR TITLE
#14 Updated to latest Java Client to remove security warnings

### DIFF
--- a/nifi-nar-bundles/nifi-marklogic-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-marklogic-bundle/pom.xml
@@ -32,9 +32,8 @@
     <properties>
         <nifi.version>1.9.0-SNAPSHOT</nifi.version>
         <marklogicnar.version>1.9.0-SNAPSHOT</marklogicnar.version>
-        <marklogicclientapi.version>4.1.1</marklogicclientapi.version>
-        <mljavaclientutil.version>3.9.0</mljavaclientutil.version>
-        <marklogicdatamovementcomponents.version>1.0</marklogicdatamovementcomponents.version>
+        <marklogicclientapi.version>4.1.2</marklogicclientapi.version>
+        <mljavaclientutil.version>3.10.0</mljavaclientutil.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
This should remove the security warnings that Github is reporting for jackson-databind.