### PR TITLE
Upgrade MarkLogic Java Client API to 4.2.0

### DIFF
--- a/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/TestDataMovementManager.java
+++ b/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/TestDataMovementManager.java
@@ -28,6 +28,7 @@ import com.marklogic.client.datamovement.QueryBatcher;
 import com.marklogic.client.datamovement.WriteBatcher;
 import com.marklogic.client.query.QueryDefinition;
 import com.marklogic.client.query.RawCombinedQueryDefinition;
+import com.marklogic.client.query.RawCtsQueryDefinition;
 import com.marklogic.client.query.RawStructuredQueryDefinition;
 import com.marklogic.client.query.StringQueryDefinition;
 import com.marklogic.client.query.StructuredQueryDefinition;
@@ -96,7 +97,13 @@ class TestDataMovementManager implements DataMovementManager {
         return new TestQueryBatcher(query);
     }
 
-    @Override
+	@Override
+	public QueryBatcher newQueryBatcher(RawCtsQueryDefinition query) {
+        queryDef = query;
+        return new TestQueryBatcher(query);
+	}
+
+	@Override
     public QueryBatcher newQueryBatcher(Iterator<String> iterator) {
         return null;
     }

--- a/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/TestQueryBatcher.java
+++ b/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/TestQueryBatcher.java
@@ -16,6 +16,7 @@
  */
 package org.apache.nifi.marklogic.processor;
 
+import java.util.Calendar;
 import java.util.concurrent.TimeUnit;
 
 import com.marklogic.client.DatabaseClient;
@@ -191,4 +192,14 @@ class TestQueryBatcher implements QueryBatcher {
     public QueryDefinition getQueryDefinition() {
         return queryDef;
     }
+
+	@Override
+	public Calendar getJobStartTime() {
+		return null;
+	}
+
+	@Override
+	public Calendar getJobEndTime() {
+		return null;
+	}
 }

--- a/nifi-nar-bundles/nifi-marklogic-bundle/pom.xml
+++ b/nifi-nar-bundles/nifi-marklogic-bundle/pom.xml
@@ -32,8 +32,8 @@
     <properties>
         <nifi.version>1.9.1</nifi.version>
         <marklogicnar.version>1.9.1.1-incubator</marklogicnar.version>
-        <marklogicclientapi.version>4.1.1</marklogicclientapi.version>
-        <mljavaclientutil.version>3.9.0</mljavaclientutil.version>
+        <marklogicclientapi.version>4.2.0</marklogicclientapi.version>
+        <mljavaclientutil.version>3.12.0</mljavaclientutil.version>
         <marklogicdatamovementcomponents.version>1.0</marklogicdatamovementcomponents.version>
     </properties>
 


### PR DESCRIPTION
Upgrade MarkLogic Java Client API to 4.2.0. This will remove the security warning
