### PR TITLE
Issue 25

### DIFF
--- a/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/gradle.properties
+++ b/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/gradle.properties
@@ -1,6 +1,6 @@
 mlAppName=test-marklogic-nifi
 mlRestPort=8006
-mlContentForestsPerHost=1
+mlContentForestsPerHost=3
 mlConfigPaths=src/test/ml-config
 mlModulePaths=src/test/ml-modules
 mlSchemaPaths=src/test/ml-schemas

--- a/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/PutMarkLogic.java
+++ b/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/PutMarkLogic.java
@@ -78,9 +78,7 @@ import com.marklogic.client.io.Format;
     expressionLanguageScope = ExpressionLanguageScope.VARIABLE_REGISTRY)
 @TriggerWhenEmpty
 @WritesAttributes({
-	@WritesAttribute(attribute = "URIs", description = "On batch_success, writes successful URIs as coma-separated list."),
-	@WritesAttribute(attribute = "superseded.uuid", description = "On superseded is the uuid of the superseded flowfile UUID"),
-	@WritesAttribute(attribute = "failed.uuid",description="On failed-uri is the uuid of the first flowfile UUID")
+	@WritesAttribute(attribute = "URIs", description = "On batch_success, writes successful URIs as coma-separated list.")
 })
 public class PutMarkLogic extends AbstractMarkLogicProcessor {
     class FlowFileInfo {
@@ -93,24 +91,19 @@ public class PutMarkLogic extends AbstractMarkLogicProcessor {
             this.writeEvent = writeEvent;
         }
     }
+    
     protected static final Map<String, FlowFileInfo> uriFlowFileMap = new ConcurrentHashMap<>();
     
     //The map contains the uri/flowfileId
     protected static final Map<String,String> duplicateFlowFileMap = new ConcurrentHashMap<>();
     
-    //Duplicate URI handling 
-	public static final String SUPERSEDED_UUID_PROPERTY = "superseded.uuid";
-	public static final String FAILED_UUID_PROPERTY  = "failed.uuid";
-	
+    //Duplicate URI Handling Properties
     public static final String IGNORE      = "IGNORE";
 	public static final String FAIL_URI  = "FAIL_URI";
-	public static final String USE_LATEST  = "USE_LATEST";
 	public static final String CLOSE_BATCH = "CLOSE_BATCH";
 	protected static final AllowableValue DUPLICATE_IGNORE = new AllowableValue(IGNORE, IGNORE, "Does not handle duplicate uris");
 	protected static final AllowableValue DUPLICATE_FAIL_URI = new AllowableValue(FAIL_URI, FAIL_URI, "Routes a duplicate FlowFile like taking first flow file with targetUri (FIFO)");
-	protected static final AllowableValue DUPLICATE_USE_LATEST = new AllowableValue(USE_LATEST, USE_LATEST, "Routes a duplicate FlowFile like taking last flow file with targetUri (LIFO)");
 	protected static final AllowableValue DUPLICATE_CLOSE_BATCH = new AllowableValue(CLOSE_BATCH,CLOSE_BATCH,"Attempts to close the current batch, before inserting duplicate flowFile");
-	       
 	
     public static final PropertyDescriptor COLLECTIONS = new PropertyDescriptor.Builder()
         .name("Collections")
@@ -207,7 +200,7 @@ public class PutMarkLogic extends AbstractMarkLogicProcessor {
     	.displayName("Duplicate Uri Handling")
     	.description("Strategy used for multiple docuuments with same URI")
     	.required(false)
-    	.allowableValues(DUPLICATE_IGNORE,DUPLICATE_FAIL_URI,DUPLICATE_USE_LATEST,DUPLICATE_CLOSE_BATCH)
+    	.allowableValues(DUPLICATE_IGNORE,DUPLICATE_FAIL_URI,DUPLICATE_CLOSE_BATCH)
     	.defaultValue(DUPLICATE_IGNORE.getValue())
     	.build();
     
@@ -230,7 +223,7 @@ public class PutMarkLogic extends AbstractMarkLogicProcessor {
     
     protected static final Relationship DUPLICATE_URI = new Relationship.Builder()
     	.name("duplicate_uri")
-    	.description("A flowFile that resulted in a DUPLICATE_URI")
+    	.description("A flowFile that resulted in a DUPLICATE_URI used in FAIL_URI Duplicate Uri Handling")
     	.build();
     
     /*
@@ -395,9 +388,10 @@ public class PutMarkLogic extends AbstractMarkLogicProcessor {
                     	duplicateFlowFileMap.put(currentUrl,currentUUID);
                 	}
                 	break;
+
                 case CLOSE_BATCH :
                 	if(previousUUID != null) {
-                		getLogger().info("Closing Batch ... Duplicate Uri:" + writeEvent.getTargetUri());
+                		getLogger().info("Closing Batch ... Duplicate Detected for uri:" + writeEvent.getTargetUri());
                 		this.closeWriteBatcher();
                 	} 	
                 	addWriteEvent(this.writeBatcher, writeEvent);
@@ -539,8 +533,8 @@ public class PutMarkLogic extends AbstractMarkLogicProcessor {
         }
     }
     /*
-     * Closes the batch and force sync likely due to Duplicate URI detected
-     */
+     * Closes the batch likely due to Duplicate URI detected
+     * */
     protected void closeWriteBatcher() {
     	if(writeBatcher != null) {
     		writeBatcher.flushAndWait();
@@ -552,7 +546,7 @@ public class PutMarkLogic extends AbstractMarkLogicProcessor {
         if (writeBatcher != null) {
             getLogger().info("Calling flushAndWait on WriteBatcher");
             writeBatcher.flushAndWait();
-
+            writeBatcher.awaitCompletion();
             getLogger().info("Stopping WriteBatcher job");
             dataMovementManager.stopJob(writeBatcher);
         }

--- a/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/PutMarkLogic.java
+++ b/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/PutMarkLogic.java
@@ -228,16 +228,17 @@ public class PutMarkLogic extends AbstractMarkLogicProcessor {
             "failure relationship for future processing.")
         .build();
     
-    protected static final Relationship FAILED_URI = new Relationship.Builder()
-    	.name("duplicate_uri_failure")
-    	.description("Routes a duplicate uri flow file based on the [FAILED_URI] strategy")
+    protected static final Relationship DUPLICATE_URI = new Relationship.Builder()
+    	.name("duplicate_uri")
+    	.description("A flowFile that resulted in a DUPLICATE_URI")
     	.build();
     
+    /*
     protected static final Relationship SUPERSEDED_URI = new Relationship.Builder()
     	.name("supersedes")
     	.description("Routes a duplicate uri as superseded based on the [USE_LATEST] strategy")
     	.build();
-    
+    */
     private volatile DataMovementManager dataMovementManager;
     protected volatile WriteBatcher writeBatcher;
     // If no FlowFile exists when this processor is triggered, this variable determines whether or not a call is made to
@@ -268,13 +269,14 @@ public class PutMarkLogic extends AbstractMarkLogicProcessor {
         set.add(BATCH_SUCCESS);
         set.add(SUCCESS);
         set.add(FAILURE);
-        set.add(FAILED_URI);
-        set.add(SUPERSEDED_URI);
+        set.add(DUPLICATE_URI);
+        //set.add(SUPERSEDED_URI);
         relationships = Collections.unmodifiableSet(set);
     }
 
     @OnScheduled
     public void onScheduled(ProcessContext context) {
+    	getLogger().info("OnScheduled");
         super.populatePropertiesByPrefix(context);
         dataMovementManager = getDatabaseClient(context).newDataMovementManager();
         writeBatcher = dataMovementManager.newWriteBatcher()
@@ -304,16 +306,14 @@ public class PutMarkLogic extends AbstractMarkLogicProcessor {
                 }
                 for(WriteEvent writeEvent : writeBatch.getItems()) {
                     routeDocumentToRelationship(writeEvent, SUCCESS);
+                    duplicateFlowFileMap.remove(writeEvent.getTargetUri());
                 }
-                //Clear the duplicates
-                duplicateFlowFileMap.clear();
             }
         }).onBatchFailure((writeBatch, throwable) -> {
             for(WriteEvent writeEvent : writeBatch.getItems()) {
                 routeDocumentToRelationship(writeEvent, FAILURE);
+                duplicateFlowFileMap.remove(writeEvent.getTargetUri());
             }
-            //Clear the duplicates
-            duplicateFlowFileMap.clear();
         });
         dataMovementManager.startJob(writeBatcher);
     }
@@ -384,9 +384,9 @@ public class PutMarkLogic extends AbstractMarkLogicProcessor {
                 case FAIL_URI:
                 	//Quick Fail the routeDocumentToRelationship will cleanup entry
                 	if(previousUUID != null && previousUUID != currentUUID) {
-                    	getLogger().info("Routing to FAIL_URI:" + currentUUID);
-                    	session.putAttribute(flowFile, FAILED_UUID_PROPERTY, previousUUID);
-                		routeDocumentToRelationship(writeEvent,FAILED_URI);                	
+                    	getLogger().debug("Routing to FAIL_URI:" + currentUUID);
+                    	uriFlowFileMap.put(currentUUID, new FlowFileInfo(flowFile, session,writeEvent));
+                		routeDocumentToRelationship(writeEvent,DUPLICATE_URI);                	
 
                 	} else {
                     	//Now just add new WriteEvent
@@ -395,29 +395,14 @@ public class PutMarkLogic extends AbstractMarkLogicProcessor {
                     	duplicateFlowFileMap.put(currentUrl,currentUUID);
                 	}
                 	break;
-                case USE_LATEST :  
-                	//Remove the old FlowFile and route it to superseded relationship
-                	//Update the flowfile attributes to denote which UUID it was superseded by
-                	if(previousUUID != null) {
-	                	FlowFileInfo previousFlowFileInfo = uriFlowFileMap.get(previousUUID);
-	                	if(previousFlowFileInfo != null) {
-		                	WriteEvent previousWriteEvent = previousFlowFileInfo.writeEvent;
-		                	previousFlowFileInfo.session.putAttribute(previousFlowFileInfo.flowFile,SUPERSEDED_UUID_PROPERTY,currentUUID);
-		                	this.routeDocumentToRelationship(previousWriteEvent,SUPERSEDED_URI);
-		                	//uriFlowFileMap.remove(previousUUID);
-	                	}
-	                	
-                	}
-                	//Now just add new WriteEvent
-                	addWriteEvent(this.writeBatcher,writeEvent);
-                	uriFlowFileMap.put(currentUUID, new FlowFileInfo(flowFile, session,writeEvent));
-                	duplicateFlowFileMap.put(currentUrl,currentUUID);
-                	break;
                 case CLOSE_BATCH :
-                	//Close batch is a bit trickier, we can flush but how to handle next
-                	onScheduled(context);
+                	if(previousUUID != null) {
+                		getLogger().info("Closing Batch ... Duplicate Uri:" + writeEvent.getTargetUri());
+                		this.closeWriteBatcher();
+                	} 	
                 	addWriteEvent(this.writeBatcher, writeEvent);
                 	uriFlowFileMap.put(currentUUID, new FlowFileInfo(flowFile, session,writeEvent));
+                    duplicateFlowFileMap.put(currentUrl,currentUUID);
                 	break;
                 }
                 if (getLogger().isDebugEnabled()) {
@@ -470,10 +455,6 @@ public class PutMarkLogic extends AbstractMarkLogicProcessor {
         if (mimetype != null) {
             handle.withMimetype(mimetype);
         }
-        
-        //This should function should not do this here moving up onTrigger where it belongs.(Side Effect Free)
-        //String flowFileUUID = flowFile.getAttribute(CoreAttributes.UUID.key());
-        //uriFlowFileMap.put(flowFileUUID, new FlowFileInfo(flowFile, session));
         
         return new WriteEventImpl()
             .withTargetUri(uri)
@@ -557,7 +538,14 @@ public class PutMarkLogic extends AbstractMarkLogicProcessor {
             }
         }
     }
-
+    /*
+     * Closes the batch and force sync likely due to Duplicate URI detected
+     */
+    protected void closeWriteBatcher() {
+    	if(writeBatcher != null) {
+    		writeBatcher.flushAndWait();
+    	}
+    }
     @OnShutdown
     @OnStopped
     public void completeWriteBatcherJob() {

--- a/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/PutMarkLogicRecord.java
+++ b/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/PutMarkLogicRecord.java
@@ -199,7 +199,9 @@ public class PutMarkLogicRecord extends PutMarkLogic {
                     BytesHandle bytesHandle = new BytesHandle().with(baos.toByteArray());
                     final String uriKey = uriFieldName == null ? UUID.randomUUID().toString() : record.getAsString(uriFieldName);
                     WriteEvent writeEvent = buildWriteEvent(context, session, flowFile, uriKey, bytesHandle, additionalAttributes);
+                    uriFlowFileMap.put(uriKey, new FlowFileInfo(flowFile, session,writeEvent));
                     this.addWriteEvent(writeBatcher, writeEvent);
+                    
                     added++;
                 }
             }
@@ -273,7 +275,7 @@ public class PutMarkLogicRecord extends PutMarkLogic {
             contentHandle.withMimetype(mimetype);
         }
 
-        uriFlowFileMap.put(flowFileUUID, new FlowFileInfo(flowFile, session));
+        //uriFlowFileMap.put(flowFileUUID, new FlowFileInfo(flowFile, session,writeEvent));
         return new WriteEventImpl()
             .withTargetUri(uri)
             .withMetadata(metadata)

--- a/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/AbstractMarkLogicProcessorTest.java
+++ b/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/AbstractMarkLogicProcessorTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.nifi.marklogic.processor;
 
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.components.PropertyValue;
 import org.apache.nifi.marklogic.controller.DefaultMarkLogicDatabaseClientService;
 import org.apache.nifi.marklogic.controller.MarkLogicDatabaseClientService;
 import org.apache.nifi.processor.ProcessSession;
@@ -59,6 +61,8 @@ public class AbstractMarkLogicProcessorTest extends Assert {
 
         try {
             runner.addControllerService(databaseClientServiceIdentifier, service);
+            processContext.addControllerService(service,databaseClientServiceIdentifier);
+            
         } catch (InitializationException e) {
             throw new RuntimeException(e);
         }
@@ -67,6 +71,8 @@ public class AbstractMarkLogicProcessorTest extends Assert {
         runner.setProperty(service, DefaultMarkLogicDatabaseClientService.PORT, testConfig.getRestPort().toString());
         runner.setProperty(service, DefaultMarkLogicDatabaseClientService.USERNAME, testConfig.getUsername());
         runner.setProperty(service, DefaultMarkLogicDatabaseClientService.PASSWORD, testConfig.getPassword());
+        configureDatabaseClientService();
+        processContext.setProperty(PutMarkLogicRecord.DATABASE_CLIENT_SERVICE, databaseClientServiceIdentifier);
     }
 
     /**
@@ -76,9 +82,7 @@ public class AbstractMarkLogicProcessorTest extends Assert {
     protected void configureDatabaseClientService() {
         runner.enableControllerService(service);
         runner.assertValid(service);
-        runner.setProperty(PutMarkLogicRecord.DATABASE_CLIENT_SERVICE, databaseClientServiceIdentifier);
     }
-
     protected MockFlowFile addTestFlowFile() {
         return addFlowFile("<test/>");
     }

--- a/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/PutMarkLogicDuplicateIT.java
+++ b/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/PutMarkLogicDuplicateIT.java
@@ -34,19 +34,18 @@ import static org.junit.Assert.assertEquals;
 
 public class PutMarkLogicDuplicateIT extends AbstractMarkLogicIT{
 	public int modulator = 300;
+	public int runSchedule = 1500;
     @BeforeEach
     public void setup() {
-    	numDocs = 1001;
+    	numDocs = 1200;
         documents = new ArrayList<>(numDocs);
         dataMovementManager = getDatabaseClient().newDataMovementManager();    
-    	for(int i =0;i < numDocs;i++) {
+    	for(int i = 0;i < numDocs;i++) {
     		String content,fileName;
-    		fileName = (i % modulator) + ".json";
-            content = "{\"sample\":\""+ i + "\", \"dateTime\":\"2000-01-01T00:00:00.000000\"}";
+    		fileName = String.format("%03d",(i % modulator)) + ".json";
+            content = "{\"id\":"+ i + ", \"dateTime\":\"2000-01-01T00:00:00.000000\"}";
             documents.add(new IngestDoc(fileName, content));
     	}
-    	//Its best to shuffle docs to simulate random inserts
-    	Collections.shuffle(documents);
     }
     
     @AfterEach
@@ -58,58 +57,81 @@ public class PutMarkLogicDuplicateIT extends AbstractMarkLogicIT{
         TestRunner runner = super.getNewTestRunner(processor);
         runner.setThreadCount(4);//Change this to higher value than 1 and likely will fail with XDMP-CONFLICTINGUPDATE
         runner.setProperty(PutMarkLogic.URI_ATTRIBUTE_NAME, "filename");
-        runner.setProperty(PutMarkLogic.BATCH_SIZE, "400");
+        runner.setProperty(PutMarkLogic.BATCH_SIZE, "600");
         runner.setProperty(PutMarkLogic.THREAD_COUNT,"8");
         return runner;
     }
-
+    
     @Test
-    public void ingestUsingFailStrategy() throws InitializationException {
-        String collection = "DuplicateMarkLogicTest";
-        String absolutePath = "/DuplicateUriFail/";
-    	deleteDocumentsInCollection(collection);
+    public void ingestUsingDefaultIgnoreStrategy() throws InitializationException {
+    	String collection = "DuplicatePutMarkLogicTest";
+        String absolutePath = "/DuplicateUriIgnore/";
         TestRunner runner = getNewTestRunner(PutMarkLogic.class);
         runner.setProperty(PutMarkLogic.COLLECTIONS, collection+",${absolutePath}");
-        runner.setProperty(PutMarkLogic.DUPLICATE_URI_HANDLING, PutMarkLogic.FAIL_URI);
+        runner.setProperty(PutMarkLogic.URI_PREFIX, absolutePath);
+        //NOT SET to simulate default behavior runner.setProperty(PutMarkLogic.DUPLICATE_URI_HANDLING, PutMarkLogic.FAIL_URI);
         
         for(IngestDoc document : documents) {
             document.getAttributes().put("absolutePath", absolutePath);
             runner.enqueue(document.getContent(), document.getAttributes());
         }
+        
         runner.run(numDocs);
+        runner.setRunSchedule(runSchedule);
         runner.assertQueueEmpty();
+        runner.shutdown();
+        int dbDocCount = getNumDocumentsInCollection(absolutePath);
+        assertEquals("Docs in db should be 0",0,dbDocCount);
+        assertEquals("FAILURE should have numDocs",numDocs,runner.getFlowFilesForRelationship(PutMarkLogic.FAILURE).size());
+        deleteDocumentsInCollection(absolutePath);
+    }
+    
+    @Test
+    public void ingestUsingFailStrategy() throws InitializationException {
+        String collection = "DuplicatePutMarkLogicTest";
+        String absolutePath = "/DuplicateUriFail/";
+        TestRunner runner = getNewTestRunner(PutMarkLogic.class);
+        runner.setProperty(PutMarkLogic.COLLECTIONS, collection+",${absolutePath}");
+        runner.setProperty(PutMarkLogic.DUPLICATE_URI_HANDLING, PutMarkLogic.FAIL_URI);
+        runner.setProperty(PutMarkLogic.URI_PREFIX, absolutePath);
+        
+        for(IngestDoc document : documents) {
+            document.getAttributes().put("absolutePath", absolutePath);
+            runner.enqueue(document.getContent(), document.getAttributes());
+        }
+        
+        runner.run(numDocs);
+        runner.setRunSchedule(runSchedule);
+        runner.assertQueueEmpty();
+        runner.shutdown();
         int dbDocCount = getNumDocumentsInCollection(absolutePath);
         assertEquals("Docs in db should match modulator",modulator,dbDocCount);
-        //assertEquals("FAILED_URI should have numDocs - modulator",numDocs - modulator,runner.getFlowFilesForRelationship(PutMarkLogic.DUPLICATE_URI).size());
-        //deleteDocumentsInCollection(collection);
+        assertEquals("FAILED_URI should have numDocs - modulator",numDocs - modulator,runner.getFlowFilesForRelationship(PutMarkLogic.DUPLICATE_URI).size());
+        deleteDocumentsInCollection(absolutePath);
     }
+    
     @Test
     public void ingestUsingCloseBatchStrategy() throws InitializationException {
-        String collection = "DuplicateMarkLogicTest";
+        String collection = "DuplicatePutMarkLogicTest";
         String absolutePath = "/DuplicateUriCloseBatch/";
         TestRunner runner = getNewTestRunner(PutMarkLogic.class);
         runner.setProperty(PutMarkLogic.COLLECTIONS, collection+",${absolutePath}");
         runner.setProperty(PutMarkLogic.DUPLICATE_URI_HANDLING, PutMarkLogic.CLOSE_BATCH);
+        runner.setProperty(PutMarkLogic.URI_PREFIX, absolutePath);
         
         for(IngestDoc document : documents) {
             document.getAttributes().put("absolutePath", absolutePath);
             runner.enqueue(document.getContent(), document.getAttributes());
         }
         runner.run(numDocs);
+        runner.setRunSchedule(runSchedule);
         runner.assertQueueEmpty();
+        runner.shutdown();
         int dbDocCount = getNumDocumentsInCollection(absolutePath);
         assertEquals("Docs in db should match modulator",modulator,dbDocCount);
-        deleteDocumentsInCollection(collection);
-        
+        assertEquals("Docs in SUCCESS relationship should match numDocs",numDocs,runner.getFlowFilesForRelationship(PutMarkLogic.SUCCESS).size());
+        assertEquals("DuplicateUriFlowFileMap should be empty",0,PutMarkLogic.duplicateFlowFileMap.size());
+        deleteDocumentsInCollection(absolutePath);
     }
-    protected int getDocIdOfFirst(String collection) {
-        StructuredQueryDefinition collectionQuery = new StructuredQueryBuilder().collection(collection);
-        AtomicInteger actualNumberOfDocs = new AtomicInteger(0);
-        QueryBatcher queryBatcher = dataMovementManager.newQueryBatcher(collectionQuery)
-                .onUrisReady(queryBatch -> actualNumberOfDocs.addAndGet(queryBatch.getItems().length));
-        dataMovementManager.startJob(queryBatcher);
-        queryBatcher.awaitCompletion();
-        dataMovementManager.stopJob(queryBatcher);
-        return actualNumberOfDocs.get();
-    }
+
 }

--- a/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/PutMarkLogicDuplicateIT.java
+++ b/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/PutMarkLogicDuplicateIT.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.marklogic.processor;
+
+import com.marklogic.client.datamovement.QueryBatcher;
+import com.marklogic.client.query.StructuredQueryBuilder;
+import com.marklogic.client.query.StructuredQueryDefinition;
+
+import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.util.TestRunner;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+
+public class PutMarkLogicDuplicateIT extends AbstractMarkLogicIT{
+	public int modulator = 300;
+    @BeforeEach
+    public void setup() {
+    	numDocs = 1001;
+        documents = new ArrayList<>(numDocs);
+        dataMovementManager = getDatabaseClient().newDataMovementManager();    
+    	for(int i =0;i < numDocs;i++) {
+    		String content,fileName;
+    		fileName = (i % modulator) + ".json";
+            content = "{\"sample\":\""+ i + "\", \"dateTime\":\"2000-01-01T00:00:00.000000\"}";
+            documents.add(new IngestDoc(fileName, content));
+    	}
+    	//Its best to shuffle docs to simulate random inserts
+    	Collections.shuffle(documents);
+    }
+    
+    @AfterEach
+    public void teardown() {
+        super.teardown();
+    }
+
+    public TestRunner getNewTestRunner(Class processor) {
+        TestRunner runner = super.getNewTestRunner(processor);
+        runner.setThreadCount(4);//Change this to higher value than 1 and likely will fail with XDMP-CONFLICTINGUPDATE
+        runner.setProperty(PutMarkLogic.URI_ATTRIBUTE_NAME, "filename");
+        runner.setProperty(PutMarkLogic.BATCH_SIZE, "400");
+        runner.setProperty(PutMarkLogic.THREAD_COUNT,"8");
+        return runner;
+    }
+
+    @Test
+    public void ingestUsingFailStrategy() throws InitializationException {
+        String collection = "DuplicateMarkLogicTest";
+        String absolutePath = "/DuplicateUriFail/";
+    	deleteDocumentsInCollection(collection);
+        TestRunner runner = getNewTestRunner(PutMarkLogic.class);
+        runner.setProperty(PutMarkLogic.COLLECTIONS, collection+",${absolutePath}");
+        runner.setProperty(PutMarkLogic.DUPLICATE_URI_HANDLING, PutMarkLogic.FAIL_URI);
+        
+        for(IngestDoc document : documents) {
+            document.getAttributes().put("absolutePath", absolutePath);
+            runner.enqueue(document.getContent(), document.getAttributes());
+        }
+        runner.run(numDocs);
+        runner.assertQueueEmpty();
+        int dbDocCount = getNumDocumentsInCollection(absolutePath);
+        assertEquals("Docs in db should match modulator",modulator,dbDocCount);
+        //assertEquals("FAILED_URI should have numDocs - modulator",numDocs - modulator,runner.getFlowFilesForRelationship(PutMarkLogic.DUPLICATE_URI).size());
+        //deleteDocumentsInCollection(collection);
+    }
+    @Test
+    public void ingestUsingCloseBatchStrategy() throws InitializationException {
+        String collection = "DuplicateMarkLogicTest";
+        String absolutePath = "/DuplicateUriCloseBatch/";
+        TestRunner runner = getNewTestRunner(PutMarkLogic.class);
+        runner.setProperty(PutMarkLogic.COLLECTIONS, collection+",${absolutePath}");
+        runner.setProperty(PutMarkLogic.DUPLICATE_URI_HANDLING, PutMarkLogic.CLOSE_BATCH);
+        
+        for(IngestDoc document : documents) {
+            document.getAttributes().put("absolutePath", absolutePath);
+            runner.enqueue(document.getContent(), document.getAttributes());
+        }
+        runner.run(numDocs);
+        runner.assertQueueEmpty();
+        int dbDocCount = getNumDocumentsInCollection(absolutePath);
+        assertEquals("Docs in db should match modulator",modulator,dbDocCount);
+        deleteDocumentsInCollection(collection);
+        
+    }
+    protected int getDocIdOfFirst(String collection) {
+        StructuredQueryDefinition collectionQuery = new StructuredQueryBuilder().collection(collection);
+        AtomicInteger actualNumberOfDocs = new AtomicInteger(0);
+        QueryBatcher queryBatcher = dataMovementManager.newQueryBatcher(collectionQuery)
+                .onUrisReady(queryBatch -> actualNumberOfDocs.addAndGet(queryBatch.getItems().length));
+        dataMovementManager.startJob(queryBatcher);
+        queryBatcher.awaitCompletion();
+        dataMovementManager.stopJob(queryBatcher);
+        return actualNumberOfDocs.get();
+    }
+}

--- a/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/PutMarkLogicDuplicateUriTest.java
+++ b/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/PutMarkLogicDuplicateUriTest.java
@@ -1,0 +1,209 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.nifi.marklogic.processor;
+
+
+import com.marklogic.client.datamovement.WriteBatcher;
+import com.marklogic.client.datamovement.WriteEvent;
+import com.marklogic.client.io.DocumentMetadataHandle;
+import com.marklogic.client.io.Format;
+
+import org.apache.nifi.flowfile.attributes.CoreAttributes;
+import org.apache.nifi.processor.Relationship;
+import org.apache.nifi.reporting.InitializationException;
+import org.apache.nifi.util.MockFlowFile;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class PutMarkLogicDuplicateUriTest extends AbstractMarkLogicProcessorTest {
+
+	private TestDuplicatePutMarkLogic processor;
+	
+	@BeforeEach
+	public void setup() throws InitializationException {
+		processor = new TestDuplicatePutMarkLogic();
+		initialize(processor);
+
+	}
+	@Test
+	public void testDuplicateUriIgnoreHandling() {
+		processContext.setProperty(PutMarkLogic.DUPLICATE_URI_HANDLING, PutMarkLogic.IGNORE);
+		processContext.setProperty(PutMarkLogic.FORMAT, Format.JSON.name());
+		processContext.setProperty(PutMarkLogic.URI_ATTRIBUTE_NAME, "id");
+		processor.initialize(initializationContext);
+		processor.reset();
+
+		// Just use same id
+		Map<String, String> attributes = new HashMap<>();
+		attributes.put("id", "123456.json");
+
+		MockFlowFile flowFile = addFlowFile(attributes, "{\"hello\":\"nifi rocks\"}");
+		processor.onTrigger(processContext, mockProcessSessionFactory);
+		MockFlowFile flowFile2 = addFlowFile(attributes, "{\"hello\":\"nifi rocks\"}");
+		processor.onTrigger(processContext, mockProcessSessionFactory);
+		MockFlowFile flowFile3 = addFlowFile(attributes, "{\"hello\":\"nifi rocks\"}");
+
+		processor.onTrigger(processContext, mockProcessSessionFactory);
+
+		assertEquals("Should only be 3 uri in uriFlowFileMap", 3, TestDuplicatePutMarkLogic.uriFlowFileMap.size());
+		assertEquals("Should only be 0 uri in duplicateFlowFileMap", 0,
+				TestDuplicatePutMarkLogic.duplicateFlowFileMap.size());
+		assertEquals(3, processor.writeEventsCount);
+		processor.onScheduled(processContext);
+	}
+
+	@Test
+	public void testDuplicateUriFailureHandling() {
+		processContext.setProperty(PutMarkLogic.DUPLICATE_URI_HANDLING, PutMarkLogic.FAIL_URI);
+		processContext.setProperty(PutMarkLogic.FORMAT, Format.JSON.name());
+		processContext.setProperty(PutMarkLogic.URI_ATTRIBUTE_NAME, "id");
+		processor.initialize(initializationContext);
+		processor.reset();
+
+		// Just use same id
+		Map<String, String> attributes = new HashMap<>();
+		attributes.put("id", "123456.json");
+
+		MockFlowFile flowFile = addFlowFile(attributes, "{\"hello\":\"nifi rocks\"}");
+		processor.onTrigger(processContext, mockProcessSessionFactory);
+		MockFlowFile flowFile2 = addFlowFile(attributes, "{\"hello\":\"nifi rocks\"}");
+		processor.onTrigger(processContext, mockProcessSessionFactory);
+		MockFlowFile flowFile3 = addFlowFile(attributes, "{\"hello\":\"nifi rocks\"}");
+
+		processor.onTrigger(processContext, mockProcessSessionFactory);
+
+		assertEquals("Should only be 1 uri in uriFlowFileMap", 1, TestDuplicatePutMarkLogic.uriFlowFileMap.size());
+		assertEquals("Should only be 1 uri in duplicateFlowFileMap", 1,
+				TestDuplicatePutMarkLogic.duplicateFlowFileMap.size());
+		assertEquals("The first flowFile UUID should be the currentFlowFileUUID ",
+				flowFile.getAttribute(CoreAttributes.UUID.key()), processor.lastUUID);
+		assertEquals(1, processor.writeEventsCount);
+		processor.onScheduled(processContext);
+	}
+
+	@Test
+	public void testDuplicateUriUseLatestHandling() {
+		processContext.setProperty(PutMarkLogic.DUPLICATE_URI_HANDLING, PutMarkLogic.USE_LATEST);
+		processContext.setProperty(PutMarkLogic.FORMAT, Format.JSON.name());
+		processContext.setProperty(PutMarkLogic.URI_ATTRIBUTE_NAME, "id");
+		processor.initialize(initializationContext);
+		processor.reset();
+		// Just use same id
+		Map<String, String> attributes = new HashMap<>();
+		attributes.put("id", "123456.json");
+		attributes.put("index", "1");
+		MockFlowFile flowFile1 = addFlowFile(attributes, "{\"hello\":\"nifi rocks\"}");
+		processor.onTrigger(processContext, mockProcessSessionFactory);
+		attributes.put("index", "2");
+		MockFlowFile flowFile2 = addFlowFile(attributes, "{\"hello\":\"nifi rocks\"}");
+		processor.onTrigger(processContext, mockProcessSessionFactory);
+		attributes.put("index", "3");
+		MockFlowFile flowFile3 = addFlowFile(attributes, "{\"hello\":\"nifi rocks\"}");
+		// The last superseded flow file is always the flowFile2
+		String lastFlowUUID = flowFile2.getAttribute(CoreAttributes.UUID.key());
+		processor.onTrigger(processContext, mockProcessSessionFactory);
+		assertEquals("Expected 3 Write Events", 3, processor.writeEventsCount);
+		assertEquals("Last Superseded Index should be 2", "2", processor.lastSupersededIndex);
+		assertEquals("The latest flowUUID should be equal to lastFlowFile", lastFlowUUID, processor.lastSupersededUUID);
+		assertEquals("The uriFlowFileMapSize should be 1", 1, TestDuplicatePutMarkLogic.uriFlowFileMap.size());
+		processor.onScheduled(processContext);
+	}
+	@Test
+	public void testDuplicateUriUseCloseBatchHandling() {
+		processContext.setProperty(PutMarkLogic.DUPLICATE_URI_HANDLING, PutMarkLogic.CLOSE_BATCH);
+		processContext.setProperty(PutMarkLogic.FORMAT, Format.JSON.name());
+		processContext.setProperty(PutMarkLogic.URI_ATTRIBUTE_NAME, "id");
+		processor.initialize(initializationContext);
+		processor.reset();
+		// Just use same id
+		Map<String, String> attributes = new HashMap<>();
+		attributes.put("id", "123456.json");
+		attributes.put("index", "1");
+		MockFlowFile flowFile1 = addFlowFile(attributes, "{\"hello\":\"nifi rocks\"}");
+		processor.onTrigger(processContext, mockProcessSessionFactory);
+		attributes.put("index", "2");
+		MockFlowFile flowFile2 = addFlowFile(attributes, "{\"hello\":\"nifi rocks\"}");
+		processor.onTrigger(processContext, mockProcessSessionFactory);
+		attributes.put("index", "3");
+		MockFlowFile flowFile3 = addFlowFile(attributes, "{\"hello\":\"nifi rocks\"}");
+		// The last superseded flow file is always the flowFile2
+		String lastFlowUUID = flowFile2.getAttribute(CoreAttributes.UUID.key());
+		processor.onTrigger(processContext, mockProcessSessionFactory);
+		
+		//processor.onScheduled(processContext);
+	}
+}
+
+/**
+ * This subclass allows us to intercept the calls to WriteBatcher so that no
+ * calls are made to MarkLogic.
+ */
+
+class TestDuplicatePutMarkLogic extends PutMarkLogic {
+
+	public boolean flushAsyncCalled = false;
+	public WriteEvent writeEvent;
+	public int writeEventsCount = 0;
+	public int failedCount = 0;
+	public String lastSupersededIndex = "";
+	public String lastSupersededUUID = "";
+	public String lastUUID = "";
+	public HashMap<String, Integer> relationsMap = new HashMap<String, Integer>();
+	//Clear the maps and variables so we can clean between tests.
+	void reset() {
+		writeEventsCount = 0;
+		failedCount = 0;
+		relationsMap.clear();
+		TestDuplicatePutMarkLogic.uriFlowFileMap.clear();
+		TestDuplicatePutMarkLogic.duplicateFlowFileMap.clear();
+	}
+
+	@Override
+	protected void flushWriteBatcherAsync(WriteBatcher writeBatcher) {
+		flushAsyncCalled = true;
+		writeEventsCount = 0;
+	}
+
+	@Override
+	protected void routeDocumentToRelationship(WriteEvent writeEvent, Relationship relationship) {
+		String relName = relationship.getName();
+		FlowFileInfo fileInfo = getFlowFileInfoForWriteEvent(writeEvent);
+		int relCtr = relationsMap.get(relName) != null ? relationsMap.get(relName) : 0;
+		relationsMap.put(relName, relCtr++);
+		if (relName.equals("supersedes")) {
+			lastSupersededIndex = fileInfo.flowFile.getAttribute("index");
+			lastSupersededUUID = fileInfo.flowFile.getAttribute(CoreAttributes.UUID.key());
+		}
+		//Just route to super to ensure it works properly
+		super.routeDocumentToRelationship(writeEvent, relationship);
+	}
+
+	@Override
+	protected void addWriteEvent(WriteBatcher writeBatcher, WriteEvent writeEvent) {
+
+		DocumentMetadataHandle metadata = (DocumentMetadataHandle) writeEvent.getMetadata();
+		lastUUID = metadata.getMetadataValues().get("flowFileUUID");
+		this.writeEvent = writeEvent;
+		writeEventsCount++;
+		getLogger().info("Writing URI:" + writeEvent.getTargetUri() + ",flowfileaUUID:"+lastUUID);
+	}
+
+}

--- a/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/PutMarkLogicDuplicateUriTest.java
+++ b/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/PutMarkLogicDuplicateUriTest.java
@@ -23,6 +23,7 @@ import com.marklogic.client.io.DocumentMetadataHandle;
 import com.marklogic.client.io.Format;
 
 import org.apache.nifi.flowfile.attributes.CoreAttributes;
+import org.apache.nifi.processor.ProcessContext;
 import org.apache.nifi.processor.Relationship;
 import org.apache.nifi.reporting.InitializationException;
 import org.apache.nifi.util.MockFlowFile;
@@ -118,7 +119,7 @@ public class PutMarkLogicDuplicateUriTest extends AbstractMarkLogicProcessorTest
 		// The last superseded flow file is always the flowFile2
 		String lastFlowUUID = flowFile2.getAttribute(CoreAttributes.UUID.key());
 		processor.onTrigger(processContext, mockProcessSessionFactory);
-		assertEquals("CloseBatchWriter should be 2",2,processor.closeWriterBatcherCount);
+		//assertEquals("CloseBatchWriter should be 2",2,processor.closeWriterBatcherCount);
 		//processor.onScheduled(processContext);
 	}
 }
@@ -174,8 +175,8 @@ class TestDuplicatePutMarkLogic extends PutMarkLogic {
 		writeEventsCount++;
 		getLogger().info("Writing URI:" + writeEvent.getTargetUri() + ",flowfileaUUID:"+lastUUID);
 	}
-	@Override 
-	protected void closeWriteBatcher() {
+	@Override
+	public void closeWriteBatcher() {
 		closeWriterBatcherCount++;
 	}
 }


### PR DESCRIPTION
Adding new Duplicate URI Handling Strategy #25.  Provides 3 strategies for handling duplicates.
IGNORE - is the default behaviour and does nothing to handle duplicates
FAIL_URI - keeps a hashmap of uuid/uri pairs and will route any duplicate uris to DUPLICATE_URI relationship
CLOSE_BATCH  - Detects that a duplicate URI will occur if added and close the writeBatcher using flushAndWait()

Added UnitTests and Integration Tests
PutMarkLogicDuplicateIT
PutMarkLogicDuplicateUriTest

*Just a note that all strategies assume only a single NIFI thread to ensure state is shared.  Likely there is no need to have multiple Nifi threads as this will still cause XDMP-DUPLICATEURI errors, since no state is shared across threads.