### PR TITLE
fix unit test errors from commit c0d8bc

### DIFF
--- a/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/AbstractMarkLogicProcessorTest.java
+++ b/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/AbstractMarkLogicProcessorTest.java
@@ -61,7 +61,6 @@ public class AbstractMarkLogicProcessorTest extends Assert {
 
         try {
             runner.addControllerService(databaseClientServiceIdentifier, service);
-            processContext.addControllerService(service,databaseClientServiceIdentifier);
             
         } catch (InitializationException e) {
             throw new RuntimeException(e);
@@ -71,8 +70,6 @@ public class AbstractMarkLogicProcessorTest extends Assert {
         runner.setProperty(service, DefaultMarkLogicDatabaseClientService.PORT, testConfig.getRestPort().toString());
         runner.setProperty(service, DefaultMarkLogicDatabaseClientService.USERNAME, testConfig.getUsername());
         runner.setProperty(service, DefaultMarkLogicDatabaseClientService.PASSWORD, testConfig.getPassword());
-        configureDatabaseClientService();
-        processContext.setProperty(PutMarkLogicRecord.DATABASE_CLIENT_SERVICE, databaseClientServiceIdentifier);
     }
 
     /**

--- a/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/PutMarkLogicRecordTest.java
+++ b/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/PutMarkLogicRecordTest.java
@@ -26,6 +26,7 @@ import org.apache.nifi.controller.AbstractControllerService;
 import org.apache.nifi.controller.ControllerService;
 import org.apache.nifi.flowfile.FlowFile;
 import org.apache.nifi.logging.ComponentLog;
+import org.apache.nifi.marklogic.processor.ExecuteScriptMarkLogicTest.TestExecuteScriptMarkLogic;
 import org.apache.nifi.reporting.InitializationException;
 import org.apache.nifi.serialization.RecordReader;
 import org.apache.nifi.serialization.RecordReaderFactory;
@@ -49,6 +50,7 @@ public class PutMarkLogicRecordTest extends AbstractMarkLogicProcessorTest {
     public void setup() throws InitializationException {
         processor = new TestPutMarkLogicRecord();
         initialize(processor);
+        runner.setProperty(TestExecuteScriptMarkLogic.DATABASE_CLIENT_SERVICE, databaseClientServiceIdentifier);
         recordReader = new MockRecordParser();
         recordReader.addSchemaField("docID", RecordFieldType.STRING);
         recordWriter = new MockRecordWriter("\"docID\"");


### PR DESCRIPTION
Fix unit test errors by commit c0d8bc. That commit changed AbstractMarkLogicProcessorTest which caused several existing unit tests to fail. Fix is not ideal but gets the tests to pass.