### PR TITLE
Adding ProvenanceTransformer to PROCESSOR file

### DIFF
--- a/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
+++ b/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
@@ -22,3 +22,4 @@ org.apache.nifi.marklogic.processor.PutMarkLogic
 org.apache.nifi.marklogic.processor.PutMarkLogicRecord
 org.apache.nifi.marklogic.processor.QueryMarkLogic
 org.apache.nifi.marklogic.processor.QueryRowsMarkLogic
+org.apache.nifi.marklogic.processor.ProvenanceTransformer


### PR DESCRIPTION
Adding ProvenanceTransformer to PROCESSOR file

/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
