### PR TITLE
Can now run a flow via RunFlowMarkLogic

### DIFF
--- a/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/pom.xml
+++ b/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/pom.xml
@@ -52,6 +52,35 @@
         </dependency>
         <dependency>
             <groupId>com.marklogic</groupId>
+            <artifactId>marklogic-data-hub</artifactId>
+            <version>5.2.0</version>
+            <!-- Excluding DH stuff we don't need. Also, the inclusion of Spring Boot stuff caused a mysterious error of
+            spring-core dependencies not being found. -->
+            <exclusions>
+                <exclusion>
+                    <groupId>com.marklogic</groupId>
+                    <artifactId>mlcp-util</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.beust</groupId>
+                    <artifactId>jcommander</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.springframework.integration</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.jaegertracing</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.marklogic</groupId>
             <artifactId>marklogic-client-api</artifactId>
             <version>${marklogicclientapi.version}</version>
         </dependency>
@@ -152,12 +181,6 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>1.7.22</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-core</artifactId>
-            <version>5.1.4.RELEASE</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/RunFlowMarkLogic.java
+++ b/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/main/java/org/apache/nifi/marklogic/processor/RunFlowMarkLogic.java
@@ -1,0 +1,237 @@
+package org.apache.nifi.marklogic.processor;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marklogic.client.DatabaseClientFactory;
+import com.marklogic.client.ext.DatabaseClientConfig;
+import com.marklogic.hub.DatabaseKind;
+import com.marklogic.hub.flow.FlowInputs;
+import com.marklogic.hub.flow.FlowRunner;
+import com.marklogic.hub.flow.RunFlowResponse;
+import com.marklogic.hub.flow.impl.FlowRunnerImpl;
+import com.marklogic.hub.impl.HubConfigImpl;
+import org.apache.nifi.annotation.behavior.InputRequirement;
+import org.apache.nifi.annotation.documentation.CapabilityDescription;
+import org.apache.nifi.annotation.documentation.Tags;
+import org.apache.nifi.annotation.lifecycle.OnScheduled;
+import org.apache.nifi.components.PropertyDescriptor;
+import org.apache.nifi.components.Validator;
+import org.apache.nifi.expression.ExpressionLanguageScope;
+import org.apache.nifi.flowfile.FlowFile;
+import org.apache.nifi.marklogic.controller.MarkLogicDatabaseClientService;
+import org.apache.nifi.processor.*;
+import org.apache.nifi.processor.exception.ProcessException;
+import org.apache.nifi.processor.util.StandardValidators;
+import org.apache.nifi.util.StringUtils;
+
+import javax.net.ssl.SSLContext;
+import java.io.IOException;
+import java.util.*;
+
+@Tags({"MarkLogic", "Data Hub Framework"})
+@InputRequirement(InputRequirement.Requirement.INPUT_ALLOWED)
+@CapabilityDescription("Run a MarkLogic Data Hub flow. This is expected to be run on non-ingestion steps, where data " +
+	"has already been ingested into MarkLogic. Ingestion steps depend on access to local files, which isn't a common " +
+	"use case for NiFi in production.")
+public class RunFlowMarkLogic extends AbstractMarkLogicProcessor {
+
+	public static final PropertyDescriptor FINAL_PORT = new PropertyDescriptor.Builder()
+		.name("Final Server Port")
+		.displayName("Final Server Port")
+		.required(true)
+		.defaultValue("8011")
+		.description("The port on which the Final REST server is hosted")
+		.addValidator(StandardValidators.PORT_VALIDATOR)
+		.expressionLanguageSupported(ExpressionLanguageScope.VARIABLE_REGISTRY)
+		.build();
+
+	public static final PropertyDescriptor JOB_PORT = new PropertyDescriptor.Builder()
+		.name("Job Server Port")
+		.displayName("Job Server Port")
+		.required(true)
+		.defaultValue("8013")
+		.description("The port on which the Job REST server is hosted")
+		.addValidator(StandardValidators.PORT_VALIDATOR)
+		.expressionLanguageSupported(ExpressionLanguageScope.VARIABLE_REGISTRY)
+		.build();
+
+	public static final PropertyDescriptor FLOW_NAME = new PropertyDescriptor.Builder()
+		.name("Flow Name")
+		.displayName("Flow Name")
+		.description("Name of the Data Hub flow to run")
+		.required(true)
+		.addValidator(StandardValidators.NON_EMPTY_VALIDATOR)
+		.expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+		.build();
+
+	public static final PropertyDescriptor STEPS = new PropertyDescriptor.Builder()
+		.name("Steps")
+		.displayName("Steps")
+		.description("Comma-delimited string of step numbers to run")
+		.addValidator(Validator.VALID)
+		.expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+		.build();
+
+	public static final PropertyDescriptor JOB_ID = new PropertyDescriptor.Builder()
+		.name("Job ID")
+		.displayName("Job ID")
+		.description("ID for the Data Hub job")
+		.required(false)
+		.addValidator(Validator.VALID)
+		.expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+		.build();
+
+	public static final PropertyDescriptor OPTIONS_JSON = new PropertyDescriptor.Builder()
+		.name("Options JSON")
+		.displayName("Options JSON")
+		.description("JSON object defining options for running the flow")
+		.required(false)
+		.addValidator(Validator.VALID)
+		.expressionLanguageSupported(ExpressionLanguageScope.FLOWFILE_ATTRIBUTES)
+		.build();
+
+	public static final Relationship FINISHED = new Relationship.Builder()
+		.name("finished")
+		.description("If the flow finishes, then regardless of its outcome, the JSON response will be sent to this relationship. " +
+			"If an exception is thrown when running the flow, then a NiFi ProcessException will be thrown instead.")
+		.build();
+
+	private HubConfigImpl hubConfig;
+
+	@Override
+	public void init(final ProcessorInitializationContext context) {
+		List<PropertyDescriptor> list = new ArrayList<>();
+		list.add(DATABASE_CLIENT_SERVICE);
+		list.add(FINAL_PORT);
+		list.add(JOB_PORT);
+		list.add(FLOW_NAME);
+		list.add(STEPS);
+		list.add(JOB_ID);
+		list.add(OPTIONS_JSON);
+		properties = Collections.unmodifiableList(list);
+
+		Set<Relationship> set = new HashSet<>();
+		set.add(FINISHED);
+		relationships = Collections.unmodifiableSet(set);
+	}
+
+	/**
+	 * When the processor is scheduled, initialize a HubConfigImpl based on the inputs provided to the
+	 * MarkLogicDatabaseClientService. The DatabaseClient from this service cannot be reused, as DHF instantiates its
+	 * own set of DatabaseClients.
+	 *
+	 * @param context
+	 */
+	@OnScheduled
+	public void onScheduled(ProcessContext context) {
+		DatabaseClientConfig clientConfig = context.getProperty(DATABASE_CLIENT_SERVICE)
+			.asControllerService(MarkLogicDatabaseClientService.class)
+			.getDatabaseClientConfig();
+		getLogger().info("Initializing HubConfig");
+		this.hubConfig = initializeHubConfig(context, clientConfig);
+		getLogger().info("Initialized HubConfig");
+	}
+
+	@Override
+	public void onTrigger(ProcessContext context, ProcessSessionFactory sessionFactory) throws ProcessException {
+		final ProcessSession session = sessionFactory.createSession();
+
+		FlowFile flowFile = session.get();
+		if (flowFile == null) {
+			flowFile = session.create();
+		}
+
+		try {
+			FlowInputs inputs = buildFlowInputs(context, flowFile);
+			FlowRunner flowRunner = new FlowRunnerImpl(hubConfig);
+			if (inputs.getSteps() != null) {
+				getLogger().info(String.format("Running steps %s in flow %s", inputs.getSteps(), inputs.getFlowName()));
+			} else {
+				getLogger().info(String.format("Running flow %s", inputs.getFlowName()));
+			}
+
+			RunFlowResponse response = flowRunner.runFlow(inputs);
+			flowRunner.awaitCompletion();
+			if (inputs.getSteps() != null) {
+				getLogger().info(String.format("Finished running steps %s in flow %s", inputs.getSteps(), inputs.getFlowName()));
+			} else {
+				getLogger().info(String.format("Finished running flow %s", inputs.getFlowName()));
+			}
+
+			session.write(flowFile, out -> out.write(response.toJson().getBytes()));
+			transferAndCommit(session, flowFile, FINISHED);
+		} catch (Throwable t) {
+			this.handleThrowable(t, session);
+		}
+	}
+
+	protected HubConfigImpl initializeHubConfig(ProcessContext context, DatabaseClientConfig clientConfig) {
+		HubConfigImpl hubConfig = HubConfigImpl.withDefaultProperties();
+
+		hubConfig.setHost(clientConfig.getHost());
+		hubConfig.setPort(DatabaseKind.STAGING, clientConfig.getPort());
+		hubConfig.setMlUsername(clientConfig.getUsername());
+		hubConfig.setMlPassword(clientConfig.getPassword());
+
+		hubConfig.setPort(DatabaseKind.FINAL, context.getProperty(FINAL_PORT).evaluateAttributeExpressions().asInteger());
+		hubConfig.setPort(DatabaseKind.JOB, context.getProperty(JOB_PORT).evaluateAttributeExpressions().asInteger());
+
+		hubConfig.setAuthMethod(DatabaseKind.STAGING, clientConfig.getSecurityContextType().toString());
+		hubConfig.setAuthMethod(DatabaseKind.FINAL, clientConfig.getSecurityContextType().toString());
+		hubConfig.setAuthMethod(DatabaseKind.JOB, clientConfig.getSecurityContextType().toString());
+
+		SSLContext sslContext = clientConfig.getSslContext();
+		if (sslContext != null) {
+			hubConfig.setSslContext(DatabaseKind.STAGING, sslContext);
+			hubConfig.setSslContext(DatabaseKind.FINAL, sslContext);
+			hubConfig.setSslContext(DatabaseKind.JOB, sslContext);
+			DatabaseClientFactory.SSLHostnameVerifier verifier = clientConfig.getSslHostnameVerifier();
+			if (verifier != null) {
+				hubConfig.setSslHostnameVerifier(DatabaseKind.STAGING, verifier);
+				hubConfig.setSslHostnameVerifier(DatabaseKind.FINAL, verifier);
+				hubConfig.setSslHostnameVerifier(DatabaseKind.JOB, verifier);
+			}
+		}
+
+		String externalName = clientConfig.getExternalName();
+		if (externalName != null) {
+			hubConfig.setExternalName(DatabaseKind.STAGING, externalName);
+			hubConfig.setExternalName(DatabaseKind.FINAL, externalName);
+			hubConfig.setExternalName(DatabaseKind.JOB, externalName);
+		}
+
+		return hubConfig;
+	}
+
+	protected FlowInputs buildFlowInputs(ProcessContext context, FlowFile flowFile) {
+		final String flowName = context.getProperty(FLOW_NAME).evaluateAttributeExpressions(flowFile).getValue();
+		FlowInputs inputs = new FlowInputs(flowName);
+
+		if (context.getProperty(STEPS) != null) {
+			String steps = context.getProperty(STEPS).evaluateAttributeExpressions(flowFile).getValue();
+			if (!StringUtils.isEmpty(steps)) {
+				inputs.setSteps(Arrays.asList(steps.split(",")));
+			}
+		}
+
+		if (context.getProperty(JOB_ID) != null) {
+			inputs.setJobId(context.getProperty(JOB_ID).evaluateAttributeExpressions(flowFile).getValue());
+		}
+
+		if (context.getProperty(OPTIONS_JSON) != null) {
+			String options = context.getProperty(OPTIONS_JSON).evaluateAttributeExpressions(flowFile).getValue();
+			if (!StringUtils.isEmpty(options)) {
+				Map<String, Object> map;
+				try {
+					map = new ObjectMapper().readValue(options, new TypeReference<Map<String, Object>>() {
+					});
+				} catch (IOException e) {
+					throw new ProcessException("Unable to parse JSON options: " + e.getMessage(), e);
+				}
+				inputs.setOptions(map);
+			}
+		}
+
+		return inputs;
+	}
+}

--- a/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
+++ b/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/main/resources/META-INF/services/org.apache.nifi.processor.Processor
@@ -23,3 +23,4 @@ org.apache.nifi.marklogic.processor.PutMarkLogicRecord
 org.apache.nifi.marklogic.processor.QueryMarkLogic
 org.apache.nifi.marklogic.processor.QueryRowsMarkLogic
 org.apache.nifi.marklogic.processor.ProvenanceTransformer
+org.apache.nifi.marklogic.processor.RunFlowMarkLogic

--- a/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/RunFlowMarkLogicTest.java
+++ b/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-processors/src/test/java/org/apache/nifi/marklogic/processor/RunFlowMarkLogicTest.java
@@ -1,0 +1,97 @@
+package org.apache.nifi.marklogic.processor;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.marklogic.client.DatabaseClientFactory;
+import com.marklogic.client.ext.DatabaseClientConfig;
+import com.marklogic.client.ext.SecurityContextType;
+import com.marklogic.client.ext.modulesloader.ssl.SimpleX509TrustManager;
+import com.marklogic.hub.DatabaseKind;
+import com.marklogic.hub.flow.FlowInputs;
+import com.marklogic.hub.impl.HubConfigImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Map;
+
+public class RunFlowMarkLogicTest extends AbstractMarkLogicProcessorTest {
+
+	private RunFlowMarkLogic processor;
+
+	@Before
+	public void setup() {
+		processor = new RunFlowMarkLogic();
+		initialize(processor);
+	}
+
+	@Test
+	public void initializeHubConfig() {
+		processContext.setProperty(RunFlowMarkLogic.FINAL_PORT, "9011");
+		processContext.setProperty(RunFlowMarkLogic.JOB_PORT, "9013");
+
+		DatabaseClientConfig config = new DatabaseClientConfig("somehost", 9010, "someuser", "someword");
+		config.setSecurityContextType(SecurityContextType.BASIC);
+		config.setSslContext(SimpleX509TrustManager.newSSLContext());
+		config.setSslHostnameVerifier(DatabaseClientFactory.SSLHostnameVerifier.STRICT);
+		config.setExternalName("just-testing");
+
+		HubConfigImpl hubConfig = processor.initializeHubConfig(processContext, config);
+		assertEquals("somehost", hubConfig.getHost());
+
+		assertEquals(new Integer(9010), hubConfig.getPort(DatabaseKind.STAGING));
+		assertEquals(new Integer(9011), hubConfig.getPort(DatabaseKind.FINAL));
+		assertEquals(new Integer(9013), hubConfig.getPort(DatabaseKind.JOB));
+
+		assertEquals("someuser", hubConfig.getMlUsername());
+		assertEquals("someword", hubConfig.getMlPassword());
+
+		assertEquals("BASIC", hubConfig.getAuthMethod(DatabaseKind.STAGING));
+		assertEquals("BASIC", hubConfig.getAuthMethod(DatabaseKind.JOB));
+		assertEquals("BASIC", hubConfig.getAuthMethod(DatabaseKind.FINAL));
+
+		assertNotNull(hubConfig.getSslHostnameVerifier(DatabaseKind.STAGING));
+		assertNotNull(hubConfig.getSslHostnameVerifier(DatabaseKind.FINAL));
+		assertNotNull(hubConfig.getSslHostnameVerifier(DatabaseKind.JOB));
+		assertEquals(DatabaseClientFactory.SSLHostnameVerifier.STRICT, hubConfig.getSslHostnameVerifier(DatabaseKind.STAGING));
+		assertEquals(DatabaseClientFactory.SSLHostnameVerifier.STRICT, hubConfig.getSslHostnameVerifier(DatabaseKind.FINAL));
+		assertEquals(DatabaseClientFactory.SSLHostnameVerifier.STRICT, hubConfig.getSslHostnameVerifier(DatabaseKind.JOB));
+
+		assertEquals("just-testing", hubConfig.getExternalName(DatabaseKind.STAGING));
+		assertEquals("just-testing", hubConfig.getExternalName(DatabaseKind.FINAL));
+		assertEquals("just-testing", hubConfig.getExternalName(DatabaseKind.JOB));
+	}
+
+	@Test
+	public void buildFlowInputs() {
+		ObjectMapper mapper = new ObjectMapper();
+		ObjectNode options = mapper.createObjectNode();
+		options.put("sourceQuery", "cts.collectionQuery('this-is-typically-overridden-at-runtime')");
+
+		processContext.setProperty(RunFlowMarkLogic.FLOW_NAME, "myFlow");
+		processContext.setProperty(RunFlowMarkLogic.STEPS, "2,4,5");
+		processContext.setProperty(RunFlowMarkLogic.JOB_ID, "myJobId");
+		processContext.setProperty(RunFlowMarkLogic.OPTIONS_JSON, options.toString());
+
+		FlowInputs inputs = processor.buildFlowInputs(processContext, addTestFlowFile());
+		assertEquals("myFlow", inputs.getFlowName());
+		assertEquals(3, inputs.getSteps().size());
+		assertEquals("2", inputs.getSteps().get(0));
+		assertEquals("4", inputs.getSteps().get(1));
+		assertEquals("5", inputs.getSteps().get(2));
+		assertEquals("myJobId", inputs.getJobId());
+
+		Map<String, Object> map = inputs.getOptions();
+		assertNotNull(map);
+		assertEquals("cts.collectionQuery('this-is-typically-overridden-at-runtime')", map.get("sourceQuery"));
+	}
+
+	@Test
+	public void buildMinimalFlowInputs() {
+		processContext.setProperty(RunFlowMarkLogic.FLOW_NAME, "myFlow");
+		FlowInputs inputs = processor.buildFlowInputs(processContext, addTestFlowFile());
+		assertEquals("myFlow", inputs.getFlowName());
+		assertNull(inputs.getSteps());
+		assertNull(inputs.getJobId());
+		assertNull(inputs.getOptions());
+	}
+}

--- a/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-services-api/pom.xml
+++ b/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-services-api/pom.xml
@@ -41,6 +41,25 @@
             <artifactId>marklogic-client-api</artifactId>
             <version>${marklogicclientapi.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.marklogic</groupId>
+            <artifactId>ml-javaclient-util</artifactId>
+            <version>${mljavaclientutil.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.marklogic</groupId>
+                    <artifactId>marklogic-xcc</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-context</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.jdom</groupId>
+                    <artifactId>jdom2</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 
 </project>

--- a/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-services-api/src/main/java/org/apache/nifi/marklogic/controller/MarkLogicDatabaseClientService.java
+++ b/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-services-api/src/main/java/org/apache/nifi/marklogic/controller/MarkLogicDatabaseClientService.java
@@ -17,10 +17,13 @@
 package org.apache.nifi.marklogic.controller;
 
 import com.marklogic.client.DatabaseClient;
+import com.marklogic.client.ext.DatabaseClientConfig;
 import org.apache.nifi.controller.ControllerService;
 
 public interface MarkLogicDatabaseClientService extends ControllerService {
 
     DatabaseClient getDatabaseClient();
+
+    DatabaseClientConfig getDatabaseClientConfig();
 
 }

--- a/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-services/pom.xml
+++ b/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-services/pom.xml
@@ -53,25 +53,6 @@
             <version>${marklogicnar.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.marklogic</groupId>
-            <artifactId>ml-javaclient-util</artifactId>
-            <version>${mljavaclientutil.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.marklogic</groupId>
-                    <artifactId>marklogic-xcc</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.springframework</groupId>
-                    <artifactId>spring-context</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.jdom</groupId>
-                    <artifactId>jdom2</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>org.apache.nifi</groupId>
             <artifactId>nifi-ssl-context-service-api</artifactId>
             <version>${nifi.version}</version>

--- a/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-services/src/main/java/org/apache/nifi/marklogic/controller/DefaultMarkLogicDatabaseClientService.java
+++ b/nifi-nar-bundles/nifi-marklogic-bundle/nifi-marklogic-services/src/main/java/org/apache/nifi/marklogic/controller/DefaultMarkLogicDatabaseClientService.java
@@ -54,6 +54,8 @@ public class DefaultMarkLogicDatabaseClientService extends AbstractControllerSer
     private static List<PropertyDescriptor> properties;
 
     private DatabaseClient databaseClient;
+    private DatabaseClientConfig databaseClientConfig;
+
     public static final PropertyDescriptor HOST = new PropertyDescriptor.Builder()
         .name("Host")
         .displayName("Host")
@@ -164,8 +166,8 @@ public class DefaultMarkLogicDatabaseClientService extends AbstractControllerSer
     @OnEnabled
     public void onEnabled(ConfigurationContext context) {
         getLogger().info("Creating DatabaseClient");
-        DatabaseClientConfig config = buildDatabaseClientConfig(context);
-        databaseClient = new DefaultConfiguredDatabaseClientFactory().newDatabaseClient(config);
+        databaseClientConfig = buildDatabaseClientConfig(context);
+        databaseClient = new DefaultConfiguredDatabaseClientFactory().newDatabaseClient(databaseClientConfig);
     }
 
     @OnDisabled
@@ -233,6 +235,11 @@ public class DefaultMarkLogicDatabaseClientService extends AbstractControllerSer
 	@Override
     public DatabaseClient getDatabaseClient() {
         return databaseClient;
+    }
+
+    @Override
+    public DatabaseClientConfig getDatabaseClientConfig() {
+        return databaseClientConfig;
     }
 
     @Override


### PR DESCRIPTION
Had to add a method to MarkLogicDatabaseClientService so that the DatabaseClientConfig can be accessed and reused.